### PR TITLE
Update bower.json license and change the hashbang of bin/pulldasher

### DIFF
--- a/bin/pulldasher
+++ b/bin/pulldasher
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 var fs = require('fs');
 var config = require(__dirname + '/../config.js');
 var debug = require('debug')('pulldasher:bin');

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   ],
   "description": "A dashboard for github pull-requests that keeps itself up-to-date",
   "main": "bin/pulldasher",
-  "license": "Copyright iFixit. All rights reserved.",
+  "license": "MIT",
   "private": true,
   "dependencies": {
     "bootstrap"      : "3.3.2",


### PR DESCRIPTION
The project is licensed under the MIT License, so the bower.json configuration
file should reflect that.

This also changes the hashbang in bin/pulldasher to /usr/bin/env instead of /bin/env .
On both Ubuntu and OSX I was recieving a 'bad interpreter' error, because env 
was under /usr/bin/ instead of /bin/.

cr_req 0