### PR TITLE
Don't always show debug indicators

### DIFF
--- a/controllers/main.js
+++ b/controllers/main.js
@@ -1,12 +1,14 @@
 var socketAuthenticator = require('../lib/socket-auth');
 var socketio = require('../package').dependencies['socket.io'];
+var config = require('../config');
 
 module.exports = {
    index: function(req, res) {
       res.render('current/index', {
          socketToken: socketAuthenticator.getTokenForUser(req.user),
          socketVersion: socketio,
-         user: req.user.username
+         user: req.user.username,
+         debug: config.debug
       });
    }
 };

--- a/views/standard/index.html
+++ b/views/standard/index.html
@@ -1,7 +1,8 @@
 <script>
    var App = {
       socketToken: "<%= socketToken %>",
-      user: "<%= user %>"
+      user: "<%= user %>",
+      debug: <%= debug %>
    };
 </script>
 <nav class="navbar navbar-default" role="navigation">

--- a/views/standard/index.html
+++ b/views/standard/index.html
@@ -9,7 +9,7 @@
       App.debugStart = function debugStart() {
          App.debug = true;
          _manager.trigger();
-      }
+      };
    });
 </script>
 <nav class="navbar navbar-default" role="navigation">

--- a/views/standard/index.html
+++ b/views/standard/index.html
@@ -4,6 +4,13 @@
       user: "<%= user %>",
       debug: <%= debug %>
    };
+
+   require(['pullManager'], function(_manager) {
+      App.debugStart = function debugStart() {
+         App.debug = true;
+         _manager.trigger();
+      }
+   });
 </script>
 <nav class="navbar navbar-default" role="navigation">
    <div class="container-fluid">

--- a/views/standard/spec/debugIndicators.js
+++ b/views/standard/spec/debugIndicators.js
@@ -1,4 +1,8 @@
 define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 'socket'], function($, _, utils, aUtils, _manager, socket) {
+   // Don't show indicators if the debug setting is off.
+   if (!App.debug)
+      return;
+
    return {
       rerender: function(pulls, node) {
          var button = $('<span>');

--- a/views/standard/spec/debugIndicators.js
+++ b/views/standard/spec/debugIndicators.js
@@ -1,7 +1,8 @@
 define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 'socket'], function($, _, utils, aUtils, _manager, socket) {
    // Don't show indicators if the debug setting is off.
-   if (!App.debug)
+   if (!App.debug) {
       return;
+   }
 
    return {
       rerender: function(pulls, node) {

--- a/views/standard/spec/debugIndicators.js
+++ b/views/standard/spec/debugIndicators.js
@@ -23,10 +23,6 @@ define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 
       }),
 
       rendertime: whenDebug(function(pulls, node) {
-         // Don't show indicators if the debug setting is off.
-         if (!App.debug) {
-            return;
-         }
          node.text((new Date()).toLocaleDateString('en-us', {'hour': 'numeric', 'minute': 'numeric', 'second': 'numeric'}));
          node.attr('title', 'Date of last rerender');
          node.tooltip({'placement': 'auto top'});
@@ -34,10 +30,6 @@ define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 
       }),
 
       offline: whenDebug(function(pulls, node) {
-         // Don't show indicators if the debug setting is off.
-         if (!App.debug) {
-            return;
-         }
          var button = $('<span>');
          button.addClass('glyphicon glyphicon-plane');
          button.on('click', function() {

--- a/views/standard/spec/debugIndicators.js
+++ b/views/standard/spec/debugIndicators.js
@@ -1,11 +1,17 @@
 define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 'socket'], function($, _, utils, aUtils, _manager, socket) {
-   // Don't show indicators if the debug setting is off.
-   if (!App.debug) {
-      return;
-   }
-
+   var whenDebug = function(f) {
+      // This function will run f if App.debug is true. f will be passed any
+      // arguments to this function
+      return function() {
+         // Don't show indicators if the debug setting is off.
+         if (!App.debug) {
+            return;
+         }
+         f.apply(this, arguments);
+      };
+   };
    return {
-      rerender: function(pulls, node) {
+      rerender: whenDebug(function(pulls, node) {
          var button = $('<span>');
          button.addClass('glyphicon glyphicon-blackboard');
          button.on('click', function() {
@@ -14,16 +20,24 @@ define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 
          button.attr('title', 'Rerender page');
          button.tooltip({'placement': 'auto top'});
          node.append(button);
-      },
+      }),
 
-      rendertime: function(pulls, node) {
+      rendertime: whenDebug(function(pulls, node) {
+         // Don't show indicators if the debug setting is off.
+         if (!App.debug) {
+            return;
+         }
          node.text((new Date()).toLocaleDateString('en-us', {'hour': 'numeric', 'minute': 'numeric', 'second': 'numeric'}));
          node.attr('title', 'Date of last rerender');
          node.tooltip({'placement': 'auto top'});
          console.log("Last render: " + new Date());
-      },
+      }),
 
-      offline: function(pulls, node) {
+      offline: whenDebug(function(pulls, node) {
+         // Don't show indicators if the debug setting is off.
+         if (!App.debug) {
+            return;
+         }
          var button = $('<span>');
          button.addClass('glyphicon glyphicon-plane');
          button.on('click', function() {
@@ -44,6 +58,6 @@ define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 
          button.attr('title', 'Airplane mode');
          button.tooltip({'placement': 'auto top'});
          node.append(button);
-      }
+      })
    };
 });


### PR DESCRIPTION
This adds functionality to only show the debug indicators when the `debug` setting in 
`config.js` is set to `true`.

This feature also allows the user to enter debug mode on the client without having 
to reload the page and lose the current state they have on the page.

To enter debug mode manually, they can open the console and run `App.debugStart()`.
This will set the `App.debug` value to `true` and then rerender the view with the debug indicators.