### PR TITLE
Add  documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-Welcome to Pulldasher, the self-hosted to-do list for GitHub repositories.
+# Pulldasher
+Pulldasher is self-hosted to-do list for GitHub repositories.
 Pulldasher tracks your pull requests and displays them according to their
 current state. It sports a flexible template system, allowing you to customize
 it extensively without touching the core code.
 
 Pulldasher is written primarily in JavaScript, using Node.js. See the
-`package.json` and `bower.json` files for more on the front- and back-end
+[`package.json`](package.json/) and [`bower.json`](bower.json/) files for more on the front- and back-end
 dependencies, respectively.
 
 To run Pulldasher, you'll need MySQL as well as Node. MySQL is used for
 statistics-gathering and some sorting and filtering.
 
-# Installation
+## Getting Started
 1. `make`
 2. `cp config.example.js config.js; $EDITOR config.js`
 3. Create a new MySQL database and source the schema.sql file.
@@ -19,7 +20,7 @@ statistics-gathering and some sorting and filtering.
  * `source schema.sql;`
 4. `bin/pulldasher`
 
-# Use
+## Use
 Pulldasher is driven by tags in pull requests and pull comments. Normally, it
 assumes that two code review and one quality assurance signoff will be
 required per pull. This can be adjusted on a per-pull basis by using the
@@ -30,21 +31,21 @@ the pull is considered ready. Conversely, if a pull only touches test code, you
 might put only `qa_req 0` on it to say that it doesn't need to be QAed, since
 it should break tests if there's anything wrong with it.
 
-When you have CRed a pull, you add a comment to it with `CR :emoji:` in it.
+When you CR a pull, add a comment to it with `CR :emoji:` in it.
 (`emoji` is simply a word or words between colons; we often use GitHub emoji,
 which follow this format.) This comment is considered a _signoff_. Pulldasher
 will update the pull's display to indicate that one of the required CRs is
-completed.  Similarly, when you have QAed a pull, you add a comment containing
+completed.  Similarly, when you QA a pull, add a comment containing
 `QA :emoji:`, and the number of QA signoffs will increase.
 
 ## Magic Features
 There's a couple features which aren't exposed clearly through the UI:
 
-### Hover Copy
+#### Hover Copy
 If you hover over a pull and type `ctrl-c` (`command-c` on a Mac), the branch
 name of the pull will be copied to your clipboard.
 
-### Filter parameters
+#### Filter parameters
 Two query string parameters are available to filter the displayed pulls:
 
 1. `assigned`: Providing a comma-separated list of usernames to the `assigned`
@@ -54,7 +55,7 @@ Two query string parameters are available to filter the displayed pulls:
    `milestone` parameter will filter the pulls to only those on the specified
    milestones.
 
-# Architecture
+## Architecture
 When first started, the Pulldasher server fetches information about the current
 pulls in the repo from GitHub. It then monitors GitHub hooks for updated
 information on the current pulls. When a client connects initially, the server
@@ -62,13 +63,13 @@ authenticates it and then (assuming it passes) sends it a data dump of the
 active pulls.  The main filtering and sorting of pulls takes place on the client
 side.
 
-# Customization
+## Customization
 
-## UI
+### UI
 Pulldasher is designed to be customizable through the files in the
 [`views/`](views/) directory. See the README there for the full details.
 
-## Signatures
+### Signatures
 Signatures are customizable through `config.js`.
 
 The defaults are
@@ -103,3 +104,7 @@ specify the `QA` and `CR` signatures to be
    regex: /\bTested <QA>\b/i
 }
 ```
+
+## License
+
+Pulldasher is released under the [MIT License](LICENSE/).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Pulldasher tracks your pull requests and displays them according to their
 current state. It sports a flexible template system, allowing you to customize
 it extensively without touching the core code.
 
+![pulldasher-image](https://cloud.githubusercontent.com/assets/2539016/11315808/78af398e-8fad-11e5-81d4-b59ae6109dec.png)
+
 Pulldasher is written primarily in JavaScript, using Node.js. See the
 [`package.json`](package.json/) and [`bower.json`](bower.json/) files for more on the front- and back-end
 dependencies, respectively.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,46 @@
-## Installation
+Welcome to Pulldasher, the self-hosted to-do list for GitHub repositories.
+Pulldasher tracks your pull requests and displays them according to their
+current state. It sports a flexible template system, allowing you to customize
+it extensively without touching the core code.
+
+Pulldasher is written primarily in JavaScript, using Node.js. See the
+`package.json` and `bower.json` files for more on the front- and back-end
+dependencies, respectively.
+
+To run Pulldasher, you'll need MySQL as well as Node. MySQL is used for
+statistics-gathering and some sorting and filtering.
+
+# Installation
 1. `make`
-2. `cp config.example.js config.js; vim config.js`
+2. `cp config.example.js config.js; $EDITOR config.js`
 3. `bin/pulldasher`
+
+# Use
+Pulldasher is driven by tags in pull requests and pull comments. Normally, it
+assumes that two code review and one quality assurance signoff will be
+required per pull. This can be adjusted on a per-pull basis by using the
+`cr_req` and `qa_req` tags in a pull description. For example, if I write a
+pull that touches some really dangerous code, I might add the `cr_req 3` and
+`qa_req 2` tags to it, requiring three CR signoffsand two QA signoffs before
+the pull is considered ready. Conversely, if a pull only touches test code, I
+might put only `qa_req 0` on it to say that it doesn't need to be QAed, since
+it should break tests if there's anything wrong with it.
+
+When I have CRed a pull, I add a comment to it with `CR :emoji:` in it.
+(`emoji` is simply a word or words between colons; we often use GitHub emoji,
+which follow this format.) This comment is considered a _signoff_. Pulldasher
+will update the pull's display to indicate that one of the required CRs is
+completed.  Similarly, when I have QAed a pull, I add a comment containing `QA
+:emoji:`, and the number of QA signoffs will increase.
+
+# Architecture
+When first started, the Pulldasher server fetches information about the current
+pulls in the repo from GitHub. It then monitors GitHub hooks for updated
+information on the current pulls. When a client connects initially, the server
+authenticates it and then (assuming it passes) sends it a data dump of the
+active pulls.  The main filtering and sorting of pulls takes place on the client
+side.
+
+# Customization
+Pulldasher is designed to be customizable through the files in the
+[`views/`](views/) directory. See the README there for the full details.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ will update the pull's display to indicate that one of the required CRs is
 completed.  Similarly, when I have QAed a pull, I add a comment containing `QA
 :emoji:`, and the number of QA signoffs will increase.
 
+## Magic Features
+There's a couple features which aren't exposed clearly through the UI:
+
+### Hover Copy
+If you hover over a pull and type `ctrl-c` (`command-c` on a Mac), the branch of
+the pull will be copied to your clipboard.
+
+### Filter parameters
+Two query string parameters are available to filter the displayed pulls:
+
+1. `assigned`: Providing a comma-separated list of usernames to the `assigned`
+   parameter will filter the pulls to only those assigned to those users.
+
+2. `milestone`: Providing a comma-separated list of milestones to the
+   `milestone` parameter will filter the pulls to only those on the specified
+   milestones.
+
 # Architecture
 When first started, the Pulldasher server fetches information about the current
 pulls in the repo from GitHub. It then monitors GitHub hooks for updated

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ completed.  Similarly, when I have QAed a pull, I add a comment containing `QA
 There's a couple features which aren't exposed clearly through the UI:
 
 ### Hover Copy
-If you hover over a pull and type `ctrl-c` (`command-c` on a Mac), the branch of
-the pull will be copied to your clipboard.
+If you hover over a pull and type `ctrl-c` (`command-c` on a Mac), the branch
+name of the pull will be copied to your clipboard.
 
 ### Filter parameters
 Two query string parameters are available to filter the displayed pulls:

--- a/README.md
+++ b/README.md
@@ -53,9 +53,14 @@ Two query string parameters are available to filter the displayed pulls:
 1. `assigned`: Providing a comma-separated list of usernames to the `assigned`
    parameter will filter the pulls to only those assigned to those users.
 
+   ```ex. https://pulldasher.example.com?assigned=copperwall,scotttherobot,davidrans```
+
 2. `milestone`: Providing a comma-separated list of milestones to the
    `milestone` parameter will filter the pulls to only those on the specified
    milestones.
+
+   ```ex. https://pulldasher.example.com?milestone=site-redesign,12/5,12/19```
+
 
 ## Architecture
 When first started, the Pulldasher server fetches information about the current

--- a/README.md
+++ b/README.md
@@ -13,25 +13,29 @@ statistics-gathering and some sorting and filtering.
 # Installation
 1. `make`
 2. `cp config.example.js config.js; $EDITOR config.js`
-3. `bin/pulldasher`
+3. Create a new MySQL database and source the schema.sql file.
+ * `create database pulldasher;`
+ * `use pulldasher;`
+ * `source schema.sql;`
+4. `bin/pulldasher`
 
 # Use
 Pulldasher is driven by tags in pull requests and pull comments. Normally, it
 assumes that two code review and one quality assurance signoff will be
 required per pull. This can be adjusted on a per-pull basis by using the
-`cr_req` and `qa_req` tags in a pull description. For example, if I write a
-pull that touches some really dangerous code, I might add the `cr_req 3` and
-`qa_req 2` tags to it, requiring three CR signoffsand two QA signoffs before
-the pull is considered ready. Conversely, if a pull only touches test code, I
+`cr_req` and `qa_req` tags in a pull description. For example, if you write a
+pull that touches some really dangerous code, you might add the `cr_req 3` and
+`qa_req 2` tags to it, requiring three CR signoffs and two QA signoffs before
+the pull is considered ready. Conversely, if a pull only touches test code, you
 might put only `qa_req 0` on it to say that it doesn't need to be QAed, since
 it should break tests if there's anything wrong with it.
 
-When I have CRed a pull, I add a comment to it with `CR :emoji:` in it.
+When you have CRed a pull, you add a comment to it with `CR :emoji:` in it.
 (`emoji` is simply a word or words between colons; we often use GitHub emoji,
 which follow this format.) This comment is considered a _signoff_. Pulldasher
 will update the pull's display to indicate that one of the required CRs is
-completed.  Similarly, when I have QAed a pull, I add a comment containing `QA
-:emoji:`, and the number of QA signoffs will increase.
+completed.  Similarly, when you have QAed a pull, you add a comment containing
+`QA :emoji:`, and the number of QA signoffs will increase.
 
 ## Magic Features
 There's a couple features which aren't exposed clearly through the UI:
@@ -59,5 +63,43 @@ active pulls.  The main filtering and sorting of pulls takes place on the client
 side.
 
 # Customization
+
+## UI
 Pulldasher is designed to be customizable through the files in the
 [`views/`](views/) directory. See the README there for the full details.
+
+## Signatures
+Signatures are customizable through `config.js`.
+
+The defaults are
+
+```
+# Give a code review or quality assurance signoff.
+CR :emoji:
+QA :emoji:
+
+# Mark a pull as blocked and in need of development work.
+dev_block :emoji:
+un_dev_block :emoji:
+
+# Mark a pull as blocked on deployment once all signoff requirements are met.
+deploy_block :emoji:
+un_deploy_block :emoji:
+```
+
+However, signatures can be also specified by a regular expression.
+
+If your team's convention is to say `LGTM :code:` or `Tested <QA>`, you can
+specify the `QA` and `CR` signatures to be
+
+```js
+// From config.js
+{
+   name: 'CR',
+   regex: /\bLGTM :code:\b/i
+},
+{
+   name: 'QA',
+   regex: /\bTested <QA>\b/i
+}
+```

--- a/config.example.js
+++ b/config.example.js
@@ -18,17 +18,17 @@ module.exports = {
    // 2. An API key that has access to the repo you're going to track
    // 3. A GitHub webhook on the repo you want to monitor
    github: {
-      // Get this from the GitHub application setup page
+      // Get this from the GitHub application setup page.
       clientId:     "your github application client id",
       secret:       'your github appliction secret',
-      // Where GitHub will send the user's browser after authentication
+      // Where GitHub will send the user's browser after authentication.
       callbackURL:  'http://localhost:' + port + '/auth/github/callback',
-      // An API token for the backend to make API requests with
+      // An API token for the backend to make API requests with.
       token:        "oauth api token for server-side api calls",
       // This will need to be the same secret you use on the Webhooks page for
       // the repo Pulldasher is going to monitor.
       hook_secret:  "some random string to use (?secret=oxwm5gks) to 'secure' github hook handlers",
-      // Limit access to specific users or teams
+      // Limit access to specific users or teams.
       requireOrg:   "Limit access to users belonging to this github organization",
       requireTeam:  "[Optional] Limit access to users belonging to this team name within the above github organization"
    },
@@ -37,13 +37,13 @@ module.exports = {
    },
    repo: {
       // The GitHub username of the person or organization owning the repo you
-      // want to monitor
+      // want to monitor.
      owner:       'repo owner',
-     // The name of the GitHub repo you want to monitor
+     // The name of the GitHub repo you want to monitor.
      name:        'repo name'
    },
    // The usual MySQL stuff. Like every other MySQL webapp, basically.
-   // You will need to source the `metrics.sql` file in the database to create
+   // You will need to source the `schema.sql` file in the database to create
    // all the tables that Pulldasher expects.
    mysql: {
       host: 'mysql remote host URL',
@@ -68,7 +68,7 @@ module.exports = {
       }
    ],
    // Tags which indicate a comment is significant and should be parsed.
-   // The regex may be customized to change the tag used in GitHub
+   // The regex may be customized to change the tag used in GitHub.
    tags: [
       {
          name: 'dev_block',

--- a/config.example.js
+++ b/config.example.js
@@ -1,12 +1,34 @@
 var port = process.env.PORT || 3000;
 module.exports = {
+   // This is the port Pulldasher will run on. If you want to have multiple
+   // instances of Pulldasher running on the same server, just assign them
+   // different ports.
    port: port,
+
+   // The use of the Github API in Pulldasher is slightly unconventional.
+   // Rather than using a token for the currently-logged-in user to access the
+   // API, we use one token belonging to the organization for everyone. This is
+   // driven by Pulldasher's back-end/front-end separation. Because the backend
+   // has to be able to access the API even when no one is logged into the front
+   // end, it can't use the users' tokens. The user logins are used only for
+   // determining permissions and the active user.
+   //
+   // To use Pulldasher, you'll need to set up the following on GitHub:
+   // 1. A GitHub Application for your organization
+   // 2. An API key that has access to the repo you're going to track
+   // 3. A GitHub webhook on the repo you want to monitor
    github: {
+      // Get this from the GitHub application setup page
       clientId:     "your github application client id",
       secret:       'your github appliction secret',
+      // Where GitHub will send the user's browser after authentication
       callbackURL:  'http://localhost:' + port + '/auth/github/callback',
+      // An API token for the backend to make API requests with
       token:        "oauth api token for server-side api calls",
+      // This will need to be the same secret you use on the Webhooks page for
+      // the repo Pulldasher is going to monitor.
       hook_secret:  "some random string to use (?secret=oxwm5gks) to 'secure' github hook handlers",
+      // Limit access to specific users or teams
       requireOrg:   "Limit access to users belonging to this github organization",
       requireTeam:  "[Optional] Limit access to users belonging to this team name within the above github organization"
    },
@@ -14,15 +36,25 @@ module.exports = {
       secret: "secret for signing session cookies"
    },
    repo: {
+      // The GitHub username of the person or organization owning the repo you
+      // want to monitor
      owner:       'repo owner',
+     // The name of the GitHub repo you want to monitor
      name:        'repo name'
    },
+   // The usual MySQL stuff. Like every other MySQL webapp, basically.
+   // You will need to source the `metrics.sql` file in the database to create
+   // all the tables that Pulldasher expects.
    mysql: {
       host: 'mysql remote host URL',
       db:   'database name',
       user: 'username',
       pass: 'password'
    },
+   // The tags Pulldasher uses to determine how many CR and QA are required for
+   // a given pull. The names are currently non-negotiable as far as the
+   // frontend is concerned, but the regex may be changed to your heart's
+   // content.
    body_tags: [
       {
          name: 'cr_req',
@@ -35,6 +67,8 @@ module.exports = {
          default: 1
       }
    ],
+   // Tags which indicate a comment is significant and should be parsed.
+   // The regex may be customized to change the tag used in GitHub
    tags: [
       {
          name: 'dev_block',
@@ -61,7 +95,9 @@ module.exports = {
          regex: /\bCR :[^\n:]+:/i
       }
    ],
+   // Where to store the PID of the pulldasher process when run.
    pidFile: "/var/run/pulldasher.pid",
+   // Setting this to true prints more debugging information.
    debug: true,
    // The time in ms before an unauthenticated websocket connection times out.
    unauthenticated_timeout: 10 * 1000,

--- a/public/js/IndicatorFilter.js
+++ b/public/js/IndicatorFilter.js
@@ -1,3 +1,4 @@
+// IndicatorFilter handles rendering the indicators onto each pull
 define(['jquery', 'underscore'], function($, _) {
    /**
     * @param indicators - The spec for this column's indicators. It is an

--- a/public/js/PullFilter.js
+++ b/public/js/PullFilter.js
@@ -38,6 +38,11 @@ define(['underscore'], function(_) {
       };
 
       var filter = function(pulls) {
+         // Notice that the use of tryApply on all these means that they all
+         // accept arrays as well as functions. I've only documented that for
+         // spec.selector in the user-facing docs, because it doesn't make sense
+         // for the others, but it is there. If we had a stable sort, we could
+         // use it to do cleaner sorts of things.
          pulls = tryApply(pulls, _.filter, spec.selector);
          pulls = tryApply(pulls, _.sortBy, spec.sort);
 

--- a/public/js/pageIndicatorHandler.js
+++ b/public/js/pageIndicatorHandler.js
@@ -1,3 +1,8 @@
+// This tends to fall into the "hack that works" category. This reuses
+// IndicatorFilter to handle the indicators on the entire page. There's some
+// oddity about how that has to be done (stemming from the fact that the
+// pageIndicators aren't blown away by default, unlike pull indicators (since
+// all the pulls are rerendered every time)
 define(['jquery', 'Templates', 'IndicatorFilter'], function($, Templates, IndicatorFilter) {
    /**
     * Renders the page indicators specified by spec.page_indicators

--- a/views/README.md
+++ b/views/README.md
@@ -43,7 +43,7 @@ Okay, now a guide on where to look to make a change:
   currently.
 
 ## Debug Mode
-Due to the frontend archetecture of Pulldasher, it can be hard to debug because
+Due to the frontend architecture of Pulldasher, it can be hard to debug because
 the server can send a new pull at any time. Debug mode provides switches to
 force the frontend to not respond to incoming data from the server, and allows
 you to manually rerender the front end.
@@ -53,6 +53,6 @@ There are two ways to activate debug mode:
 1. Start Pulldasher with `debug` set to true in the config (see
    `/config.example.js`)
 2. Activate debug mode from the developer console:
-   Type `debugStart()` in the console.
+   Type `App.debugStart()` in the console.
 
 Descriptions of the debug tools are available in `spec/debugIndicators.js`.

--- a/views/README.md
+++ b/views/README.md
@@ -1,0 +1,43 @@
+# Customizing Pulldasher
+The files in these directories allow you to customize Pulldasher. I'll describe
+the general directory layout, then go into detail on what the files in each part
+do.
+
+## Files
+As cloned, this directory probably contains three things:
+
+1. a directory named `standard`
+2. a file named `layout.html`
+3. this file (`README.md`).
+
+The interesting parts are in the `standard` directory.
+
+Within the `standard` directory, you should find the following things:
+
+1. `spec` A directory containing customization JavaScript.
+2. `html` A directory containing the templates that are assembled to build the
+   main page.
+3. `less` A directory containing the LESS styling for the customizable parts.
+4. `index.html` The template for the main Pulldasher page layout.
+5. `css` A directory containing the compiled version of the LESS.
+
+## Making changes
+First, a bit of terminology is in order: We call the small icons that appear on
+a pull _indicators_. By similarity of purpose and implementation, we call the
+parts that display information like the total number of open pulls and the
+number of frozen pulls _page indicators_.
+
+Okay, now a guide on where to look to make a change:
+* If you want to change the appearance of part of pulldasher, look at the `less`
+  and `html` directories and the `index.html` file.
+* If you want to add an indicator to a pull, look in the `indicators.js` file in
+  the `spec` directory.
+* If you want to add a page indicator, look in the `pageIndicators.js` file in
+  `./spec`
+* If you want to add a column... yes, it can be done, but it'll take doing.
+  You'll need to make changes in both the `./spec/columns.js` file and the
+  `index.html` file.
+* If you want to customize the behaviour of the collapsible columns, you're
+  pretty much out of luck. You'd be better off reimplementing it with column
+  triggers (not that that's hard), because it's a bit of a hack the way it is
+  currently.

--- a/views/README.md
+++ b/views/README.md
@@ -41,3 +41,18 @@ Okay, now a guide on where to look to make a change:
   pretty much out of luck. You'd be better off reimplementing it with column
   triggers (not that that's hard), because it's a bit of a hack the way it is
   currently.
+
+## Debug Mode
+Due to the frontend archetecture of Pulldasher, it can be hard to debug because
+the server can send a new pull at any time. Debug mode provides switches to
+force the frontend to not respond to incoming data from the server, and allows
+you to manually rerender the front end.
+
+There are two ways to activate debug mode:
+
+1. Start Pulldasher with `debug` set to true in the config (see
+   `/config.example.js`)
+2. Activate debug mode from the developer console:
+   Type `debugStart()` in the console.
+
+Descriptions of the debug tools are available in `spec/debugIndicators.js`.

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -22,8 +22,8 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
          id: "ciBlocked",
          // This describes how to choose the pulls to go in this column. It is a
          // function which returns `true` if a pull should go in the column and
-         // `false` otherwise. This property may also be an array, in which case
-         // the selectors are chained.
+         // `false` otherwise. This property may also be an array of functions,
+         // in which case the selectors are chained.
          selector: function(pull) {
             return !pull.dev_blocked() && !pull.build_succeeded();
          },

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -1,11 +1,34 @@
+/* `spec/columns.js`
+ *
+ * This file defines the columns which Pulldasher shows. It is required and
+ * slotted into the global config by `spec/main.js`.
+ */
+// The header here is standard RequireJS to pull in jquery and a helper library
+// which is available in `/public/js/appearanceUtils.js`
 define(['jquery', 'appearanceUtils'], function($, utils) {
+   // This array will contain one object for each column configured. Adding a
+   // column requires adding a new element to the array and adding a spot on
+   // index.html for the column to go in.
    return [
+      // This object describes a column in Pulldasher, specifically, the CI
+      // Blocked column
       {
-         title: "CI Blocked",
+         // This name will be displayed at the top of the column
+         title: "CI Blocked?",
+         // This id is used to match the column to the element it should be
+         // placed in. Pulldasher will render the column into an element with id
+         // `<id>-container`. So, for example, this column will render into the
+         // `ciBlocked-container` element in `index.js`.
          id: "ciBlocked",
+         // This describes how to choose the pulls to go in this column. It is a
+         // function which returns `true` if a pull should go in the column and
+         // `false` otherwise.
          selector: function(pull) {
             return !pull.dev_blocked() && !pull.build_succeeded();
          },
+         // This describes the sort order for the pull. It returns a numeric
+         // score for each pull. Pulls with a low score are sorted to the bottom
+         // of the column. Pulls with a high score are sorted to the top.
          sort: function(pull) {
             var score = 0;
             if (pull.is_mine()) {
@@ -21,15 +44,29 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
 
             return score;
          },
+         // Triggers provide hooks to run your own javascript on a column at
+         // various points in the column's lifecycle. Each function is passed
+         // two arguments: the column's main element and the column's container
+         // element. The function may do anything it likes.
          triggers: {
+            // This hook will be run on column creation. In this case, it sets
+            // the nice blue color on the column header.
             onCreate: function(blob, container) {
                blob.removeClass('panel-default').addClass('panel-primary');
             },
+            // This hook will be run whenever Pulldasher receives an update from
+            // the server. It should typically be used to update things about
+            // the column's appearance that are affected by its contents (or, in
+            // this case, lack thereof)
             onUpdate: function(blob, container) {
                utils.hideIfEmpty(container, blob, '.pull');
             }
          },
+         // This is a magical option (in a bad way) which makes the column
+         // collapsible. It would be better if no more such options were added.
          shrinkToButton: true
+         // Take a look at the next column for more on the parts we haven't seen
+         // yet!
       },
       {
          title: "deploy_blocked Pulls",
@@ -45,6 +82,14 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
                utils.hideIfEmpty(container, blob, '.pull');
             }
          },
+         // Now here's a new thing: indicators. As mentioned in the README,
+         // indicators provide icons and such on each pull. Each indicator is a
+         // function which will be called for each pull. It is passed the Pull
+         // object (see `/public/js/Pull.js`) and the HTML element into which it
+         // should render itself. That element can come from one of two places:
+         // either it is an element in the pull HTML template (see
+         // `html/pull.html`) or it is a new element placed in an element in the
+         // pull template with class `indicators`.
          indicators: {
             deploy_block: function deploy_block(pull, node) {
                if (pull.deploy_blocked()) {

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -4,17 +4,17 @@
  * slotted into the global config by `spec/main.js`.
  */
 // The header here is standard RequireJS to pull in jquery and a helper library
-// which is available in `/public/js/appearanceUtils.js`
+// which is available in `/public/js/appearanceUtils.js`.
 define(['jquery', 'appearanceUtils'], function($, utils) {
    // This array will contain one object for each column configured. Adding a
    // column requires adding a new element to the array and adding a spot on
    // index.html for the column to go in.
    return [
       // This object describes a column in Pulldasher, specifically, the CI
-      // Blocked column
+      // Blocked column.
       {
-         // This name will be displayed at the top of the column
-         title: "CI Blocked?",
+         // This name will be displayed at the top of the column.
+         title: "CI Blocked",
          // This id is used to match the column to the element it should be
          // placed in. Pulldasher will render the column into an element with id
          // `<id>-container`. So, for example, this column will render into the
@@ -58,7 +58,7 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
             // This hook will be run whenever Pulldasher receives an update from
             // the server. It should typically be used to update things about
             // the column's appearance that are affected by its contents (or, in
-            // this case, lack thereof)
+            // this case, lack thereof).
             onUpdate: function(blob, container) {
                utils.hideIfEmpty(container, blob, '.pull');
             }
@@ -223,7 +223,7 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
 
             if (!pull.qa_done() && signatures.user && !signatures.user.data.active) {
                // The user has an invalid signature, and the pull isn't ready.
-               // They should re-QA it
+               // They should re-QA it.
                score -= 1000;
             }
 
@@ -234,7 +234,7 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
             }
 
             if (signatures.user && signatures.user.data.active) {
-               // I've already CRd or QAd this pull
+               // I've already CRd or QAd this pull.
                score += 1000;
             }
 

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -22,7 +22,8 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
          id: "ciBlocked",
          // This describes how to choose the pulls to go in this column. It is a
          // function which returns `true` if a pull should go in the column and
-         // `false` otherwise.
+         // `false` otherwise. This property may also be an array, in which case
+         // the selectors are chained.
          selector: function(pull) {
             return !pull.dev_blocked() && !pull.build_succeeded();
          },
@@ -83,13 +84,9 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
             }
          },
          // Now here's a new thing: indicators. As mentioned in the README,
-         // indicators provide icons and such on each pull. Each indicator is a
-         // function which will be called for each pull. It is passed the Pull
-         // object (see `/public/js/Pull.js`) and the HTML element into which it
-         // should render itself. That element can come from one of two places:
-         // either it is an element in the pull HTML template (see
-         // `html/pull.html`) or it is a new element placed in an element in the
-         // pull template with class `indicators`.
+         // indicators provide icons and such on each pull. In this section, we
+         // can set the indicators for this column only. See
+         // `spec/indicators.js` for more on how indicators work.
          indicators: {
             deploy_block: function deploy_block(pull, node) {
                if (pull.deploy_blocked()) {

--- a/views/standard/spec/debugIndicators.js
+++ b/views/standard/spec/debugIndicators.js
@@ -1,3 +1,9 @@
+// This defines the debug indicators. These are a group of indicators on the
+// right-hand side of the navbar which are only visible in debugging mode. In
+// general, these should work the same way as page indicators (see
+// `spec/pageIndicators.js`).
+//
+// See the views README (`/views/README.md`) for more on activating debug mode.
 define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 'socket'], function($, _, utils, aUtils, _manager, socket) {
    var whenDebug = function(f) {
       // This function will run f if App.debug is true. f will be passed any
@@ -11,6 +17,10 @@ define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 
       };
    };
    return {
+      // Allows the user to rerender all the pulls. This does the same thing
+      // that happens when the server sends an update to a pull, but it doesn't
+      // change the pull data at all, making it easier to trigger a debugger as
+      // needed.
       rerender: whenDebug(function(pulls, node) {
          var button = $('<span>');
          button.addClass('glyphicon glyphicon-blackboard');
@@ -22,6 +32,10 @@ define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 
          node.append(button);
       }),
 
+      // This displays the last time the page was rerendered. It makes it easier
+      // to track when renders are happening. Note that it doesn't use any
+      // special hooks or anything, it just shows the date when it was last
+      // rerendered.
       rendertime: whenDebug(function(pulls, node) {
          node.text((new Date()).toLocaleDateString('en-us', {'hour': 'numeric', 'minute': 'numeric', 'second': 'numeric'}));
          node.attr('title', 'Date of last rerender');
@@ -29,6 +43,11 @@ define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils', 'pullManager', 
          console.log("Last render: " + new Date());
       }),
 
+      // Allows the user to disable all the actions that happen when the server
+      // sends an update. This doesn't actually pause updates from the server,
+      // it just makes the places that receive them into noops. Thus, it's a bit
+      // of a hack, and it has to refresh the page upon deactivation in order to
+      // ensure it's got up-to-date data.
       offline: whenDebug(function(pulls, node) {
          var button = $('<span>');
          button.addClass('glyphicon glyphicon-plane');

--- a/views/standard/spec/index.js
+++ b/views/standard/spec/index.js
@@ -1,3 +1,6 @@
+// This is the main spec file for Pulldasher. In reality, it's the only spec
+// file. The others are being required (see immediately below) and stuck in
+// their respective places in the overall config.
 define(['jquery', 'underscore', 'appearanceUtils', 'spec/utils', 'spec/pageIndicators', 'spec/indicators', 'spec/columns', 'spec/debugIndicators'], function($, _, utils, specUtils, pageIndicators, indicators, columns, debugIndicators) {
    var clipboard = $('#branch_name_clipboard');
    return {
@@ -6,8 +9,9 @@ define(['jquery', 'underscore', 'appearanceUtils', 'spec/utils', 'spec/pageIndic
       page_indicators: pageIndicators,
       debug_indicator_box: "#debug-indicators",
       debug_indicators: debugIndicators,
-      // Global filters
-      // where
+      // Global filters: These are used to set which pulls should show on the
+      // page at all. Notice that you're allowed to use multiple
+      // functions here, as in all the other selector filters.
       selector: [
          function(pull) {
             return specUtils.shouldShowPull(pull);
@@ -33,6 +37,8 @@ define(['jquery', 'underscore', 'appearanceUtils', 'spec/utils', 'spec/pageIndic
       sort: function(pull) {
          return pull.created_at;
       },
+      // This provides a hook to make modifications to each pull as it's
+      // rendered.
       adjust: function(pull, node) {
          var titleElem = node.find('.pull-title');
          utils.addTooltip(titleElem, pull.author());
@@ -41,7 +47,8 @@ define(['jquery', 'underscore', 'appearanceUtils', 'spec/utils', 'spec/pageIndic
             clipboard.val(pull.head.ref).focus().select();
          });
       },
-      // Functions to stick status information in indicators at the bottom of each pull
+      // Functions to stick status information in indicators at the bottom of
+      // each pull
       indicators: indicators,
       columns: columns
    };

--- a/views/standard/spec/index.js
+++ b/views/standard/spec/index.js
@@ -11,7 +11,8 @@ define(['jquery', 'underscore', 'appearanceUtils', 'spec/utils', 'spec/pageIndic
       debug_indicators: debugIndicators,
       // Global filters: These are used to set which pulls should show on the
       // page at all. Notice that you're allowed to use multiple
-      // functions here, as in all the other selector filters.
+      // functions here, as in all the other selector filters. See
+      // `spec/columns.js` for more on filters.
       selector: [
          function(pull) {
             return specUtils.shouldShowPull(pull);

--- a/views/standard/spec/index.js
+++ b/views/standard/spec/index.js
@@ -49,7 +49,7 @@ define(['jquery', 'underscore', 'appearanceUtils', 'spec/utils', 'spec/pageIndic
          });
       },
       // Functions to stick status information in indicators at the bottom of
-      // each pull
+      // each pull.
       indicators: indicators,
       columns: columns
    };

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -182,7 +182,7 @@ define(['jquery', 'underscore', 'appearanceUtils', 'debug'], function($, _, util
    // the indicator, then the indicator will be passed that element as the node
    // to render into.  Otherwise, a new element will be created. This makes it
    // really easy to add a basic tag on a bunch of pulls, should you wish to. An
-   // example may hel;p to make this all clearer: The `cr_remaining` indicator
+   // example may help to make this all clearer: The `cr_remaining` indicator
    // below renders into the `div` with class `cr_remaining` in the pull
    // template (which is how the check marks for CR are implemented). On the
    // other hand, there's no element with class `custom_label`, so the

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -170,7 +170,28 @@ define(['jquery', 'underscore', 'appearanceUtils', 'debug'], function($, _, util
                "title": container.html()
             });
          }
-   };
+      };
+
+   // These are indicators. Each indicator is a function which will be called
+   // for every pull. It is passed the Pull object (see `/public/js/Pull.js`)
+   // and the HTML element into which it should render itself. That element can
+   // come from one of two places: either it is an element in the pull HTML
+   // template (see `html/pull.html`) or it is a new element placed in the
+   // element in the pull template with class `indicators`. Basically, if
+   // there's an element in the pull template with a class of the same name as
+   // the indicator, then the indicator will be passed that element as the node
+   // to render into.  Otherwise, a new element will be created. This makes it
+   // really easy to add a basic tag on a bunch of pulls, should you wish to. An
+   // example may hel;p to make this all clearer: The `cr_remaining` indicator
+   // below renders into the `div` with class `cr_remaining` in the pull
+   // template (which is how the check marks for CR are implemented). On the
+   // other hand, there's no element with class `custom_label`, so the
+   // `custom_label` indicator below will be rrendered into a newly-created
+   // element on each pull.
+
+   // The indicators in this file will be called for every pull in every column,
+   // so they add information that we want regardless of the column the pull is
+   // in.
    return {
       cr_remaining: function cr_remaining(pull, node) {
          log("Working on CR on pull #" + pull.number);
@@ -255,6 +276,12 @@ define(['jquery', 'underscore', 'appearanceUtils', 'debug'], function($, _, util
             node.append(label);
          });
       },
+
+      // Here's an interesting duck! This indicator actually adds the event
+      // handler to _the refresh button_ on each pull. If you look at the pull
+      // template (`html/pull.html`), you'll see that the refresh button already
+      // has its icon. This just adds the `click` event handler. Indicators are
+      // super powerful!
       refresh: function(pull, node) {
          node.on('click', function(event) {
             event.preventDefault();

--- a/views/standard/spec/pageIndicators.js
+++ b/views/standard/spec/pageIndicators.js
@@ -1,4 +1,20 @@
+// This file contains _page indicators_. What are page indicators? They're like
+// indicators (`spec/indicators.js`), but act in summary on all the pulls in the
+// page. They're rendered into the navbar by default, but just like normal
+// indicators can also render themselves into matching elements. In the case of
+// page indicators, the elements are searched against the entire body element.
+//
+// It is also worth noting that pageIndicators are run on the full list of
+// pulls, even before the global filters (see `spec/index.js`). This enables
+// them to do things like summarize the number of pulls which _aren't_ shown on
+// the page.
 define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils'], function($, _, utils, aUtils) {
+   // This function generates the data for the CR and QA leaderboards. There's a
+   // known bug, however. When a pull is closed, the frontend doesn't discard
+   // it. But on refresh, the frontend won't get it back. This function
+   // (corrrectly) takes into account closed pulls, but we really need to be
+   // getting some of them (maybe the last week's worth or so) from the backend
+   // on startup.
    var summarize = function(pulls, node, type, extract) {
       // Clean out indicator node. This prevents re-renders from resulting in
       // junk.

--- a/views/standard/spec/utils.js
+++ b/views/standard/spec/utils.js
@@ -1,4 +1,6 @@
+// These are various utility functions for the rest of the config
 define(['underscore'], function(_) {
+   // Get a `GET` parameter from the URL
    var params = function() {
       var filters = {};
       var filterString = window.location.search;

--- a/views/standard/spec/utils.js
+++ b/views/standard/spec/utils.js
@@ -1,4 +1,4 @@
-// These are various utility functions for the rest of the config
+// These are various utility functions for the rest of the config.
 define(['underscore'], function(_) {
    // Get a `GET` parameter from the URL
    var params = function() {


### PR DESCRIPTION
Add lots of documentation (mostly about use and frontend customization).

--

This adds a documentation comments in many of the pulldasher
configuration and source files, especially `config.js`. The comments
should make it a lot easier to set up pulldasher with the correct tokens
and secrets from Github.

This also expands the README.md to include more information about
configuration, setup, and Pulldasher itself.

cr_req 1
qa_req 0