### PR TITLE
Milestones: Sort columns based on milestone due date

### DIFF
--- a/views/standard/less/pull.less
+++ b/views/standard/less/pull.less
@@ -129,3 +129,13 @@
    float: left;
    margin-right: 10px;
 }
+
+.label-milestone {
+   background-color: #EFF7FF;
+   color: #5BABF1;
+}
+
+.label-past-due {
+   background-color: #FBEBEA;
+   color: @brand-danger;
+}

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -7,7 +7,7 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
 
          if (pull.milestone.title) {
             var due_date = pull.milestone.due_on &&
-            new Date(pull.milestone.due_on);
+             new Date(pull.milestone.due_on);
 
             // If milestone is past due date.
             if (due_date && due_date < new Date()) {
@@ -92,7 +92,7 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
 
                   node.append(link);
                }
-            },
+            }
          },
          shrinkToButton: true
       },
@@ -195,7 +195,7 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
             score -= pull.status.CR.length;
 
             return score;
-         },
+         }
       },
       {
          title: "QA Pulls",

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -1,4 +1,36 @@
 define(['jquery', 'appearanceUtils'], function($, utils) {
+
+   // Sorting functions that are run on each column.
+   var globalSorts = {
+      sortByMilestone: function(pull) {
+         var score = 0;
+
+         if (pull.milestone.title) {
+            var due_date = pull.milestone.due_on &&
+            new Date(pull.milestone.due_on);
+
+            // If milestone is past due date.
+            if (due_date && due_date < new Date()) {
+               score -= 1500;
+            } else {
+               score -= 750;
+            }
+         }
+
+         return score;
+      }
+   };
+
+   /**
+    * Runs all of the functions from globalSorts on the given pull and reduces
+    * each score into a total sorting score.
+    */
+   function sortGlobally(pull) {
+      return _.reduce(globalSorts, function(score, sort) {
+         return score + sort(pull);
+      }, 0);
+   }
+
    return [
       {
          title: "CI Blocked",
@@ -7,7 +39,7 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
             return !pull.dev_blocked() && !pull.build_succeeded();
          },
          sort: function(pull) {
-            var score = 0;
+            var score = sortGlobally(pull);
             if (pull.is_mine()) {
                score -= 30;
             }
@@ -89,11 +121,12 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
          sort: function(pull) {
             var most_recent_block = pull.status.dev_block.slice(-1)[0].data;
             var date = new Date(most_recent_block.created_at);
+            var score = sortGlobally(pull);
 
             // Pulls that have been dev_blocked longer are higher priority.
-            var score = -1/date.valueOf();
+            score += -1/date.valueOf();
 
-            if(pull.is_mine()) {
+            if (pull.is_mine()) {
                score -= 1;
             }
 
@@ -127,8 +160,7 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
          sort: function(pull) {
             // The higher score is, the lower the pull will be sorted.
             // So a lower score means an item shows higher in the list.
-            var score = 0;
-
+            var score = sortGlobally(pull);
             var signatures = pull.cr_signatures;
 
             if (!pull.cr_done() && signatures.user && !signatures.user.data.active) {
@@ -175,8 +207,7 @@ define(['jquery', 'appearanceUtils'], function($, utils) {
          sort: function(pull) {
             // The higher score is, the lower the pull will be sorted.
             // So a lower score means an item shows higher in the list.
-            var score = 0;
-
+            var score = sortGlobally(pull);
             var signatures = pull.qa_signatures;
 
             if (!pull.qa_done() && signatures.user && !signatures.user.data.active) {

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -232,14 +232,24 @@ define(['jquery', 'underscore', 'appearanceUtils', 'debug'], function($, _, util
          }
 
          if (milestone.title) {
-            var label = $('<span>').addClass('label label-info');
+            var label = $('<span>').addClass('label');
             var label_text = milestone.title;
 
             // If there's a due date, show that instead of the milestone title.
             if (milestone.due_on) {
                var date = new Date(milestone.due_on);
-               label_text = (date.getMonth() + 1) + '/' + date.getDate();
-               utils.addTooltip(label, milestone.title);
+               var past_due = date.getTime() < Date.now();
+               var tooltip_text = milestone.title;
+
+               if (past_due) {
+                  label.addClass('label-past-due');
+                  tooltip_text = "Past Due: " + tooltip_text;
+               } else {
+                  label.addClass('label-milestone');
+               }
+
+               label_text = utils.formatDate(date);
+               utils.addTooltip(label, tooltip_text);
             }
 
             label.text(label_text);


### PR DESCRIPTION
This alters the sorting preferences for columns so that pulls with milestones
are placed near the top, and milestones that are past their due date are
sorted even higher towards the top.

Fixes #5 