### PR TITLE
Metrics: rebuild all pull history with cli arg

### DIFF
--- a/app.js
+++ b/app.js
@@ -122,9 +122,9 @@ function refreshAll(all) {
    var githubPulls;
 
    if (all === true) {
-      githubPulls = gitManager.getOpenPulls();
-   } else {
       githubPulls = gitManager.getAllPulls();
+   } else {
+      githubPulls = gitManager.getOpenPulls();
    }
 
    queue.pause();

--- a/app.js
+++ b/app.js
@@ -119,8 +119,13 @@ function refresh(number) {
  * open *and* closed.
  */
 function refreshAll(all) {
-   var state = all ? 'all' : 'open';
-   var githubPulls = gitManager.getAllPulls(state);
+   var githubPulls;
+
+   if (all === true) {
+      githubPulls = gitManager.getOpenPulls();
+   } else {
+      githubPulls = gitManager.getAllPulls();
+   }
 
    queue.pause();
 
@@ -141,6 +146,7 @@ function refreshAll(all) {
    });
 }
 
+// Gets all pulls, open and closed, if argument is passed.
 var all = _.contains(args, 'rebuild-history');
 
 // Called, to populate app, on startup.

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 var config = require('./config'),
+    _ = require('underscore'),
     httpServer,
     express = require('express'),
     partials = require('express-partials'),
@@ -17,6 +18,7 @@ var config = require('./config'),
     reqLogger = require('debug')('pulldasher:server:request');
     resLogger = require('debug')('pulldasher:server:response');
 
+var args = process.argv.slice(2);
 var app = express();
 
 httpServer = require('http').createServer(app)
@@ -113,10 +115,12 @@ function refresh(number) {
 }
 
 /**
- * Refreshes all open pulls.
+ * Refreshes all open pulls. If parameter `all` is true, refreshes all pulls,
+ * open *and* closed.
  */
-function refreshAll() {
-   var githubPulls = gitManager.getAllPulls();
+function refreshAll(all) {
+   var state = all ? 'all' : 'open';
+   var githubPulls = gitManager.getAllPulls(state);
 
    queue.pause();
 
@@ -137,9 +141,10 @@ function refreshAll() {
    });
 }
 
+var all = _.contains(args, 'rebuild-history');
 
 // Called, to populate app, on startup.
-refreshAll();
+refreshAll(all);
 
 /*
 @TODO: Update pulls which were open last time Pulldasher ran but are closed now.

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -37,14 +37,29 @@ module.exports = {
    },
 
    /**
+    * Get all *open* pull requests for a repo.
+    *
     * Returns a promise which resolves to an array of promises. Each promise
     * in the array resolves to GitHub's API response for a Pull Request.
     */
-   getAllPulls: function(state) {
+   getOpenPulls: function() {
       return getAll({
          user:       config.repo.owner,
          repo:       config.repo.name,
-         state:      state,
+      }).then(getAllPages);
+   },
+
+   /**
+    * Get *all* pull requests for a repo (NOTE: this could exhaust API limit).
+    *
+    * Returns a promise which resolves to an array of promises. Each promise
+    * in the array resolves to GitHub's API response for a Pull Request.
+    */
+   getAllPulls: function() {
+      return getAll({
+         user:       config.repo.owner,
+         repo:       config.repo.name,
+         state:      'all'
       }).then(getAllPages);
    },
 

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -40,10 +40,11 @@ module.exports = {
     * Returns a promise which resolves to an array of promises. Each promise
     * in the array resolves to GitHub's API response for a Pull Request.
     */
-   getAllPulls: function() {
+   getAllPulls: function(state) {
       return getAll({
          user:       config.repo.owner,
-         repo:       config.repo.name
+         repo:       config.repo.name,
+         state:      state,
       }).then(getAllPages);
    },
 


### PR DESCRIPTION
Calling `bin/pulldasher rebuild-history` will rebuild the entire
`metrics` DB looping over all pulls, both open and closed.

qa_req 0 (I tested it)

Closes #18