### PR TITLE
Example config: update to handle unicode emojis as well

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -1,4 +1,10 @@
 var port = process.env.PORT || 3000;
+
+// Support text emojis and almost all unicode emojis / symbols
+var emoji = "[\u2190-\u2BFF]|\ud83c[\udf00-\udfff]|\ud83d([\udc00-\ude4f]|[\ude80-\udeff])";
+var emojiText = ":[^\n:]+:";
+var signature = "(" + emojiText + '|' + emoji + ")";
+
 module.exports = {
    // This is the port Pulldasher will run on. If you want to have multiple
    // instances of Pulldasher running on the same server, just assign them
@@ -72,27 +78,31 @@ module.exports = {
    tags: [
       {
          name: 'dev_block',
-         regex: /\bdev_block :[^\n:]+:/i
+         // This regex supports thins like :smile: as well as the actual
+         // unicode representation of emoticons. Mainly added because github
+         // started making their autocompletor inject actual unicode emojis
+         // in the text.
+         regex: new RegExp("\\bdev_block " + signature, "i")
       },
       {
          name: 'un_dev_block',
-         regex: /\bun_dev_block :[^\n:]+:/i
+         regex: new RegExp("\\bun_dev_block " + signature, "i")
       },
       {
          name: 'deploy_block',
-         regex: /\bdeploy_block :[^\n:]+:/i
+         regex: new RegExp("\\bdeploy_block " + signature, "i")
       },
       {
          name: 'un_deploy_block',
-         regex: /\bun_deploy_block :[^\n:]+:/i
+         regex: new RegExp("\\bun_deploy_block " + signature, "i")
       },
       {
          name: 'QA',
-         regex: /\bQA :[^\n:]+:/i
+         regex: new RegExp("\\bQA " + signature, "i")
       },
       {
          name: 'CR',
-         regex: /\bCR :[^\n:]+:/i
+         regex: new RegExp("\\bCR " + signature, "i")
       }
    ],
    // Where to store the PID of the pulldasher process when run.


### PR DESCRIPTION
Github started making their emoji auto-completor inject unicode emojis
instead of ascii representations like :+1: or :smile:. This updates
the regex to detect unicode ranges that contain emojis. The regex is a
bit more permissive than needed, but the set symbols that are used
as emojis is dispersed across a smattering of unicode ranges.

Closes #26