### PR TITLE
Github: obey the rate limit!

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ var config = require('./config'),
     Signature = require('./models/signature'),
     mainController = require('./controllers/main'),
     hooksController = require('./controllers/githubHooks'),
+    debug = require('debug')('pulldasher'),
     reqLogger = require('debug')('pulldasher:server:request');
 
 var args = process.argv.slice(2);
@@ -120,27 +121,33 @@ function refreshAll(all) {
    var githubPulls;
 
    if (all === true) {
+      debug("rebuilding all pulls");
       githubPulls = gitManager.getAllPulls();
    } else {
+      debug("rebuilding all open pulls");
       githubPulls = gitManager.getOpenPulls();
    }
 
-   queue.pause();
-
    githubPulls.done(function(gPulls) {
-      var pullsUpdated = gPulls.map(function(gPull) {
+      debug("done retrieving pulls");
+      function next() {
+         if (!gPulls.length) {
+            debug("done building all pulls");
+            return;
+         }
+
+         var gPull = gPulls.shift();
+         debug("building pull %s", gPull.number);
+
+         queue.pause();
          var pull = gitManager.parse(gPull);
 
-         return new Promise(function(resolve, reject) {
-            update(pull).done(function() {
-               resolve();
-            });
+         update(pull).done(function() {
+            queue.resume();
+            next();
          });
-      });
-
-      Promise.all(pullsUpdated).done(function() {
-         queue.resume();
-      });
+      };
+      next();
    });
 }
 

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -6,20 +6,32 @@ var GithubApi = require('github'),
       debug: config.debug,
       version: '3.0.0'
     }),
-    getNextPage = Promise.denodeify(github.getNextPage.bind(github)),
     Pull = require('../models/pull'),
     Comment = require('../models/comment'),
     Label = require('../models/label'),
     Status = require('../models/status'),
-    Signature = require('../models/signature');
+    Signature = require('../models/signature')
+    rateLimit = require('./rate-limit.js');
 
 github.authenticate({
    type: 'oauth',
    token: config.github.token
 });
 
-var get    = Promise.denodeify(github.pullRequests.get);
-var getAll = Promise.denodeify(github.pullRequests.getAll);
+function denodeify(func) {
+   return rateLimit(Promise.denodeify(func));
+}
+
+var get                    = denodeify(github.pullRequests.get);
+var getAll                 = denodeify(github.pullRequests.getAll);
+var getPullEvents          = denodeify(github.issues.getEvents);
+// "issue" comments are the comments on the pull (issue) itself.
+var getPullComments        = denodeify(github.issues.getComments);
+// "review" comments are the comments on the diff of the pull
+var getPullReviewComments  = denodeify(github.pullRequests.getComments);
+var getCommit              = denodeify(github.repos.getCommits);
+var getCommitStatus        = denodeify(github.statuses.get);
+var getNextPage            = denodeify(github.getNextPage.bind(github));
 
 module.exports = {
    github: github,
@@ -39,8 +51,7 @@ module.exports = {
    /**
     * Get all *open* pull requests for a repo.
     *
-    * Returns a promise which resolves to an array of promises. Each promise
-    * in the array resolves to GitHub's API response for a Pull Request.
+    * Returns a promise which resolves to an array of all open pull requests
     */
    getOpenPulls: function() {
       return getAll({
@@ -50,10 +61,9 @@ module.exports = {
    },
 
    /**
-    * Get *all* pull requests for a repo (NOTE: this could exhaust API limit).
+    * Get *all* pull requests for a repo.
     *
-    * Returns a promise which resolves to an array of promises. Each promise
-    * in the array resolves to GitHub's API response for a Pull Request.
+    * Returns a promise which resolves to an array of all pull requests
     */
    getAllPulls: function() {
       return getAll({
@@ -142,7 +152,6 @@ module.exports = {
    },
 
    getPullEvents: function(pullNumber) {
-      var getPullEvents = Promise.denodeify(github.issues.getEvents);
       return getPullEvents({
          user: config.repo.owner,
          repo: config.repo.name,
@@ -151,8 +160,6 @@ module.exports = {
    },
 
    getPullComments: function(pullNumber) {
-      // "issue" comments are the comments on the pull (issue) itself.
-      var getPullComments = Promise.denodeify(github.issues.getComments);
       return getPullComments({
          user: config.repo.owner,
          repo: config.repo.name,
@@ -161,9 +168,7 @@ module.exports = {
    },
 
    getPullReviewComments: function(pullNumber) {
-      // "review" comments are the comments on the diff of pull
-      var getPullComments = Promise.denodeify(github.pullRequests.getComments);
-      return getPullComments({
+      return getPullReviewComments({
          user: config.repo.owner,
          repo: config.repo.name,
          number: pullNumber
@@ -171,7 +176,6 @@ module.exports = {
    },
 
    getCommit: function(sha) {
-      var getCommit = Promise.denodeify(github.repos.getCommits);
       return new Promise(function (resolve, reject){
          getCommit({
             user: config.repo.owner,
@@ -188,7 +192,6 @@ module.exports = {
       });
    },
    getCommitStatus: function(sha) {
-      var getCommitStatus = Promise.denodeify(github.statuses.get);
       return new Promise(function(resolve, reject) {
          getCommitStatus({
             user: config.repo.owner,
@@ -215,7 +218,7 @@ function getAllPages(currentPage, allResults) {
       allResults = allResults || [];
       allResults.push(currentPage);
 
-      if (!github.hasNextPage(currentPage)) {
+      if (!github.hasNextPage(currentPage) || allResults.length > 5) {
          return resolve(_.flatten(allResults));
       } 
 

--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -1,0 +1,85 @@
+var Promise = require('promise'),
+    debug = require('debug')('pulldasher:rate-limit');
+
+// Number of remaining requests that will activate the rate-limiter.
+// 5000 == always rate limit
+// 1000 == let 4000 requests go as fast as they can, then limit to one per 3s
+// Effectively, higher = more steady, but slow, lower = fast bursts, but much
+// slower as we get closer to the limit
+var chokePoint = 4950;
+
+// Wraps a promise returing function in a function that checks responses for
+// github's rate-limit headers and delays firing of requests to attempt to
+// stay under the rate limit.
+module.exports = function rateLimit(promiseFunc) {
+   return function () {
+      var args = arguments;
+      return throttleRequest().then(function() {
+         return promiseFunc.apply(null, args)
+      }).then(captureRateLimitInfo);
+   }
+}
+
+// FIFO queue of request callbacks to github
+var requestQueue = [];
+// number of requests remaining before we hit the rate limit
+var remaining = null;
+// timestamp of the next time rate limit will be reset
+var resetAt;
+
+/**
+ * Return a promise that resolves immediately (if we don't need to slow down)
+ * or resolves later with a delay if we need to stay under the rate limit.
+ */
+function throttleRequest() {
+   if (remaining !== null && remaining < chokePoint) {
+      return new Promise(function (resolve, reject) {
+         queue(resolve);
+      });
+   }
+   return Promise.resolve();
+}
+
+/**
+ * Records the rate limit headers from a response and returns the response
+ *
+ * Can be injected in a .then() chain and won't change the resolved value
+ */
+function captureRateLimitInfo(response) {
+   if (response && response.meta) {
+      remaining = Number(response.meta['x-ratelimit-remaining']);
+      if (response.meta['x-ratelimit-reset']) {
+         resetAt = Number(response.meta['x-ratelimit-reset']);
+      }
+      debug("Response received, requests remaining: %s reset at: %s", remaining, resetAt);
+   }
+   return response;
+}
+
+var drainer;
+function drainOne() {
+   if (requestQueue.length) {
+      resolve = requestQueue.shift();
+      resolve();
+      var delay = interval();
+      debug("Delayed request: %s (ms)", delay);
+      drainer = setTimeout(drainOne, delay);
+   } else {
+      drainer = null;
+   }
+}
+
+function queue(resolve) {
+   requestQueue.push(resolve);
+   startDrainer();
+}
+
+function startDrainer() {
+   if (!drainer) {
+      drainOne();
+   }
+}
+
+function interval() {
+   return (resetAt * 1000 - Date.now()) / (remaining + 1);;
+}


### PR DESCRIPTION
All hail the rate limit!

This adds some smarts to our github usage and will allow requests to
go through unimpeded until we get to the choke point, at which point
we start throttling requests such that we stay *just* under the rate
limit.

Obviously, not knowing the future means we can't be all that smart
about it.

The delay is such that if you have an unlimited number of requests
coming in, we'll stay just below the rate limit. If you reach the
choke point but only have a few more requests, they will be throttled
unnecessarily, but we'll just have to live with that.

This means that now, the rebuild-history option will totally work
without hitting the rate limit. Also, change rebuild-history to
operate on pulls one at a time, instead of thousands in parallel.

Closes #33