### PR TITLE
Debug Log: allow disabling of timestamp

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,8 +12,8 @@ var config = require('./config'),
     pullQueue  = require('./lib/pull-queue'),
     mainController = require('./controllers/main'),
     hooksController = require('./controllers/githubHooks'),
-    reqLogger = require('debug')('pulldasher:server:request'),
-    debug = require('debug')('pulldasher');
+    reqLogger = require('./lib/debug')('pulldasher:server:request'),
+    debug = require('./lib/debug')('pulldasher');
 
 var app = express();
 var httpServer = require('http').createServer(app);

--- a/bin/pulldasher
+++ b/bin/pulldasher
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 var fs = require('fs');
 var config = require(__dirname + '/../config.js');
-var debug = require('debug')('pulldasher:bin');
+var debug = require('../lib/debug')('pulldasher:bin');
 
 // Save the pid to a file if requested (for an init script)
 if (config.pidFile) {

--- a/bin/refresh-all-issues
+++ b/bin/refresh-all-issues
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-require('debug').enable(require('debug').load() || 'pulldasher:refresh*');
+require('../lib/debug').default('pulldasher:refresh*');
 
 var refresh = require('../lib/refresh');
 var db = require('../lib/db');

--- a/bin/refresh-all-pulls
+++ b/bin/refresh-all-pulls
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-require('debug').enable(require('debug').load() || 'pulldasher:refresh*');
+require('../lib/debug').default('pulldasher:refresh*');
 
 var refresh = require('../lib/refresh');
 var db = require('../lib/db');

--- a/bin/refresh-issue
+++ b/bin/refresh-issue
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-require('debug').enable(require('debug').load() || 'pulldasher:refresh*');
+require('../lib/debug').default('pulldasher:refresh*');
 
 var refresh = require('../lib/refresh');
 var db = require('../lib/db');

--- a/bin/refresh-open-issues
+++ b/bin/refresh-open-issues
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-require('debug').enable(require('debug').load() || 'pulldasher:refresh*');
+require('../lib/debug').default('pulldasher:refresh*');
 
 var refresh = require('../lib/refresh');
 var db = require('../lib/db');

--- a/bin/refresh-open-pulls
+++ b/bin/refresh-open-pulls
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-require('debug').enable(require('debug').load() || 'pulldasher:refresh*');
+require('../lib/debug').default('pulldasher:refresh*');
 
 var refresh = require('../lib/refresh');
 var db = require('../lib/db');

--- a/bin/refresh-pull
+++ b/bin/refresh-pull
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-require('debug').enable(require('debug').load() || 'pulldasher:refresh*');
+require('../lib/debug').default('pulldasher:refresh*');
 
 var refresh = require('../lib/refresh');
 var db = require('../lib/db');

--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -1,6 +1,6 @@
 var config     = require('../config'),
     Promise    = require('promise'),
-    debug      = require('debug')('pulldasher:githubHooks'),
+    debug      = require('../lib/debug')('pulldasher:githubHooks'),
     Pull       = require('../models/pull'),
     Status     = require('../models/status'),
     Signature  = require('../models/signature'),

--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -1,5 +1,5 @@
 var config = require('../config'),
-    debug = require('debug')('pulldasher:authentication'),
+    debug = require('./debug')('pulldasher:authentication'),
     github = require('./git-manager').github,
     Promise = require('promise'),
     passport = require('passport'),

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -1,5 +1,5 @@
 var _ = require('underscore'),
-    debug = require('debug')('pulldasher:db-manager'),
+    debug = require('./debug')('pulldasher:db-manager'),
     Promise = require('promise'),
     db = require('../lib/db'),
     DBIssue = require('../models/db_issue'),

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,0 +1,9 @@
+var debug = require('debug');
+module.exports = debug;
+
+if (process.env.NO_TIMESTAMP) {
+   debug.formatArgs = function(args) {
+      args[0] = this.namespace + " " + args[0] +
+       " +" + debug.humanize(this.diff);
+   };
+}

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -6,7 +6,7 @@ var GithubApi = require('github'),
       debug: config.debug,
       version: '3.0.0'
     }),
-    debug = require('debug')('pulldasher:github'),
+    debug = require('./debug')('pulldasher:github'),
     utils = require('./utils'),
     Pull = require('../models/pull'),
     Issue = require('../models/issue'),

--- a/lib/pull-manager.js
+++ b/lib/pull-manager.js
@@ -1,4 +1,4 @@
-var debug      = require('debug')('pulldasher:pull-manager'),
+var debug      = require('./debug')('pulldasher:pull-manager'),
     pullQueue  = require('./pull-queue'),
     _          = require('underscore'),
     dbManager  = require('./db-manager');

--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -1,5 +1,5 @@
 var Promise = require('promise'),
-    debug = require('debug')('pulldasher:rate-limit');
+    debug = require('./debug')('pulldasher:rate-limit');
 
 // Number of remaining requests that will activate the rate-limiter.
 // 5000 == always rate limit

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -3,7 +3,7 @@ var dbManager = require('./db-manager');
 var utils = require('./utils');
 
 var NotifyQueue = require('notify-queue');
-var debug = require('debug')('pulldasher:refresh');
+var debug = require('./debug')('pulldasher:refresh');
 var Promise = require('promise');
 
 // Queues for making all refreshes be synchronous, one at a time.

--- a/models/db_comment.js
+++ b/models/db_comment.js
@@ -1,7 +1,7 @@
 var utils = require('../lib/utils'),
     db = require('../lib/db'),
     getLogin = require('../lib/get-user-login'),
-    debug = require('debug')('pulldasher:db_comment');
+    debug = require('../lib/debug')('pulldasher:db_comment');
 
 /**
  * Builds an object representation of a row in the DB `comments` table

--- a/models/issue.js
+++ b/models/issue.js
@@ -1,7 +1,7 @@
 var utils   = require('../lib/utils');
 var _       = require('underscore');
 var config  = require('../config');
-var log     = require('debug')('pulldasher:issue');
+var log     = require('../lib/debug')('pulldasher:issue');
 var DBIssue = require('./db_issue');
 var getLogin = require('../lib/get-user-login');
 

--- a/models/pull.js
+++ b/models/pull.js
@@ -3,7 +3,7 @@ var _       = require('underscore');
 var config  = require('../config');
 var queue = require('../lib/pull-queue');
 var Promise = require('promise');
-var debug = require('debug')('pulldasher:pull');
+var debug = require('../lib/debug')('pulldasher:pull');
 var DBPull = require('./db_pull');
 var getLogin = require('../lib/get-user-login');
 


### PR DESCRIPTION
When you're logging the output through any modern logging
system (syslog, journalctl, ...) a timestamp is prepended anyway.
There's no point in adding a second timestamp.

Let's make that configurable using an ENV variable.

Closes #38
