### PR TITLE
Issues: record issue labels as well

### DIFF
--- a/app.js
+++ b/app.js
@@ -96,4 +96,5 @@ io.sockets.on('connection', function (socket) {
    }, unauthenticated_timeout);
 });
 
+debug("Listening on port %s", config.port);
 httpServer.listen(config.port);

--- a/config.example.js
+++ b/config.example.js
@@ -123,8 +123,14 @@ module.exports = {
     */
    labels: [
       {
-         name: 'difficulty',
-         regex: /^size: [0-9]+$/
+         name: "difficulty",
+         regex: /^size: [0-9]+$/,
+         // Take in a string (or null, when a label is deleted), returns the
+         // new value to be stored: issue[name] = process(label)
+         process: function (label) {
+            var match = label ? label.match(/[0-9]+/) : null;
+            return match ? parseInt(match[0], 10) : null;
+         }
       }
    ],
 

--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -141,7 +141,7 @@ function handleIssueEvent(body) {
       case "opened":
          // Always do this for opened issues because a full refresh
          // is the easiest way to get *who* assigned the initial labels.
-         return refresh.issue(body.number);
+         return refresh.issue(body.issue.number);
 
       case "labeled":
          debug('Added label: %s', body.label.name);

--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -158,7 +158,7 @@ function handleIssueEvent(body) {
             new Label(
                body.label,
                body.number,
-               body.issue.repository.name,
+               body.issue.repository.name
             )
          );
          break;

--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -149,19 +149,19 @@ function handleIssueEvent(body) {
          var label = new Label(
             body.label,
             body.issue.number,
-            body.issue.repository.name,
+            body.repository.name,
             body.sender.login,
             body.issue.updated_at
          );
          before = dbManager.insertLabel(label);
-         after = reprocessLabels(body.issue.number);
+         after = reprocessLabels(body.issue.number, body.repository.name);
          break;
       case "unlabeled":
          debug('Removed label: %s', body.label.name);
          var label = new Label(
             body.label,
             body.issue.number,
-            body.issue.repository.name
+            body.repository.name
          );
          before = dbManager.deleteLabel(label);
          after = reprocessLabels(body.issue.number);
@@ -186,13 +186,13 @@ function handleIssueEvent(body) {
  * After a label has been added or removed we have to re-process all the labels
  * in case one of them matches one of our configured label updaters.
  */
-function reprocessLabels(issueNumber) {
+function reprocessLabels(issueNumber, repo) {
    return function() {
       if (!config.labels || !config.labels.length) {
          return;
       }
       debug("Reprocessing labels for Issue #%s", issueNumber);
-      return dbManager.getIssue(issueNumber)
+      return dbManager.getIssue(issueNumber, repo)
       .then(dbManager.updateIssue);
    }
 }

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -276,6 +276,26 @@ var dbManager = module.exports = {
    },
 
    /**
+    * Returns a promise which resolves to a Pull object for the given pull
+    * number built from data stored in the database.
+    */
+   getIssue: function(number, repo) {
+      debug('Calling getIssue for issue #%s', number);
+      var q_select = 'SELECT * FROM issues WHERE number = ?';
+
+      return db.query(q_select, [number, repo]).then(function(rows) {
+         if (rows.length === 0) { return null; }
+
+         var dbIssueData  = rows[0];
+         dbManager.getLabels(number, repo)
+         .then(function(labels) {
+            debug('getIssue: retrieved issue #%s', number);
+            return Issue.getFromDB(dbIssueData, labels);
+         });
+      });
+   },
+
+   /**
     * Returns a promise which resolves to an array of Pull objects for the
     * given pull numbers built from data stored in the database.
     */
@@ -375,7 +395,7 @@ var dbManager = module.exports = {
     * Delete a single label from the database.
     */
    deleteLabel: function deleteLabel(label) {
-      debug("Calling deleteLabel for label '%s' on pull #%s",
+      debug("Calling deleteLabel for label '%s' on issue #%s",
        label.data.title, label.data.number);
       return (new DBLabel(label)).delete();
    },

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -86,6 +86,21 @@ var dbManager = module.exports = {
    },
 
    /**
+    * Takes in an Issue object, deletes, then resaves the issue and *all* the
+    * related data (labels) and returns a
+    * Promise that resolves when it's completed.
+    */
+   updateAllIssueData: function updateAllIssueData(issue) {
+      return dbManager.updateIssue(issue).then(
+      function() {
+         return dbManager.deleteLabels(issue.number)
+      }).then(function() {
+         return dbManager.insertLabels(
+          issue.labels, issue.number, /* isIssue */ true);
+      });
+   },
+
+   /**
     * Inserts a commit status into the DB. Takes a Status object as an
     * argument.
     */

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -280,14 +280,14 @@ var dbManager = module.exports = {
     * number built from data stored in the database.
     */
    getIssue: function(number, repo) {
-      debug('Calling getIssue for issue #%s', number);
+      debug('Calling getIssue for issue %s#%s - ', repo, number);
       var q_select = 'SELECT * FROM issues WHERE number = ?';
 
       return db.query(q_select, [number, repo]).then(function(rows) {
          if (rows.length === 0) { return null; }
 
          var dbIssueData  = rows[0];
-         dbManager.getLabels(number, repo)
+         return dbManager.getLabels(number, repo)
          .then(function(labels) {
             debug('getIssue: retrieved issue #%s', number);
             return Issue.getFromDB(dbIssueData, labels);
@@ -368,10 +368,12 @@ var dbManager = module.exports = {
     * Returns a promise which resolves to an array of labels for the pull.
     */
    getLabels: function getLabels(number, repo) {
+      debug('Calling getLabels for #%s - %s', number, repo);
       var q_select = '\
          SELECT * FROM pull_labels \
          WHERE number = ? AND repo_name = ?';
       return db.query(q_select, [number, repo]).then(function(rows) {
+         debug('Got %s rows', rows.length);
          return rows.map(function(row) {
             return Label.getFromDB(row);
          });

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -211,10 +211,12 @@ var dbManager = module.exports = {
    /**
     * Insert an array of (github) labels into the database.
     */
-   insertLabels: function(labels, number) {
+   insertLabels: function(labels, number, isIssue) {
       var labelsSaved = labels.map(this.insertLabel.bind(this));
       return Promise.all(labelsSaved).then(function() {
-         queue.markPullAsDirty(number);
+         if (!isIssue) {
+            queue.markPullAsDirty(number);
+         }
       });
    },
 

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -192,7 +192,7 @@ module.exports = {
          // multiple repos. The ghIssue object doesn't contain the repo name.
          var labels = getLabelsFromEvents(events, ghIssue, config.repo.name);
 
-         return new Issue.getFromGH(ghIssue, labels);
+         return Issue.getFromGH(ghIssue, labels);
       });
    },
 };

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -23,11 +23,12 @@ function denodeify(func) {
    return rateLimit(Promise.denodeify(func));
 }
 
+var api = {};
 var getPull                = denodeify(github.pullRequests.get);
 var getAllPulls            = denodeify(github.pullRequests.getAll);
 var getIssue               = denodeify(github.issues.getRepoIssue);
 var getAllIssues           = denodeify(github.issues.repoIssues);
-var getPullEvents          = denodeify(github.issues.getEvents);
+api.getIssueEvents         = denodeify(github.issues.getEvents);
 // "issue" comments are the comments on the pull (issue) itself.
 var getPullComments        = denodeify(github.issues.getComments);
 // "review" comments are the comments on the diff of the pull
@@ -113,7 +114,7 @@ module.exports = {
       var comments = module.exports.getPullComments(githubPull.number);
       var headCommit = module.exports.getCommit(githubPull.head.sha);
       var commitStatus = module.exports.getCommitStatus(githubPull.head.sha);
-      var events = module.exports.getPullEvents(githubPull.number);
+      var events = getIssueEvents(githubPull.number);
 
       // Returned to the map function. Each element of githubPulls maps to
       // a promise that resolves to a Pull.
@@ -177,12 +178,6 @@ module.exports = {
          var pull = new Pull(githubPull, signatures, comments, status, labels);
          return pull.syncToIssue();
       });
-   },
-
-   getPullEvents: function(pullNumber) {
-      return getPullEvents(params({
-         number: pullNumber
-      })).then(getAllPages);
    },
 
    getPullComments: function(pullNumber) {
@@ -301,4 +296,13 @@ function params(apiParams) {
       repo:       config.repo.name,
       per_page:   100,
    }, apiParams);
+}
+
+/**
+ * Return a promise for all issue events for the given issue / pull
+ */
+function getIssueEvents(issueNumber) {
+   return api.getIssueEvents(params({
+      number: issueNumber
+   })).then(getAllPages);
 }

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -33,7 +33,7 @@ api.getIssueEvents         = denodeify(github.issues.getEvents);
 api.getIssueComments       = denodeify(github.issues.getComments);
 // "review" comments are the comments on the diff of the pull
 api.getPullReviewComments  = denodeify(github.pullRequests.getComments);
-var getCommit              = denodeify(github.repos.getCommits);
+api.getCommit              = denodeify(github.repos.getCommits);
 var getCommitStatus        = denodeify(github.statuses.get);
 var getNextPage            = denodeify(github.getNextPage.bind(github));
 
@@ -112,7 +112,7 @@ module.exports = {
 
       var reviewComments = getPullReviewComments(githubPull.number);
       var comments = getIssueComments(githubPull.number);
-      var headCommit = module.exports.getCommit(githubPull.head.sha);
+      var headCommit = getCommit(githubPull.head.sha);
       var commitStatus = module.exports.getCommitStatus(githubPull.head.sha);
       var events = getIssueEvents(githubPull.number);
 
@@ -180,20 +180,6 @@ module.exports = {
       });
    },
 
-   getCommit: function(sha) {
-      return new Promise(function (resolve, reject){
-         getCommit(params({
-            sha: sha,
-            per_page: 1
-         })).then(function(commits) {
-            if (commits.length === 1) {
-               resolve(commits[0]);
-            } else {
-               return reject();
-            }
-         });
-      });
-   },
    getCommitStatus: function(sha) {
       return new Promise(function(resolve, reject) {
          getCommitStatus(params({
@@ -307,3 +293,17 @@ function getPullReviewComments(pullNumber) {
    })).then(getAllPages);
 }
 
+function getCommit(sha) {
+   return new Promise(function (resolve, reject){
+      api.getCommit(params({
+         sha: sha,
+         per_page: 1
+      })).then(function(commits) {
+         if (commits.length === 1) {
+            resolve(commits[0]);
+         } else {
+            return reject();
+         }
+      });
+   });
+}

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -250,8 +250,6 @@ function getLabelsFromEvents(events, ghIssue, repoName) {
       return {
          type: event.event,
          name: event.label.name,
-         number: ghIssue.number,
-         repo_name: repoName,
          user: event.actor.login,
          created_at: new Date(event.created_at)
       };
@@ -272,12 +270,33 @@ function getLabelsFromEvents(events, ghIssue, repoName) {
 
    debug("Found %s unique labels for #%s", labels.length, ghIssue.number);
 
+   // If these are available, use them as the canonical source, only augmented
+   // by the data from events. If a label is renamed, the events will retain
+   // the old name but the list of labels on the issue itself will be correct.
+   // So, if a label is renamed, we'll lose the labeler and the date.
+   if (ghIssue.labels && ghIssue.labels.length) {
+      debug("Using %s labels from the github issue", ghIssue.labels.length);
+      // Includes labeller and a time from the events api
+      var eventLabels = _.indexBy(labels, 'name');
+
+      return ghIssue.labels.map(function(label) {
+         var eventLabel = eventLabels[label.name];
+         return new Label(
+            {name: label.name},
+            ghIssue.number,
+            repoName,
+            eventLabel && eventLabel.user,
+            eventLabel && eventLabel.created_at
+         );
+      });
+   }
+
    // Construct Label objects.
    return labels.map(function(label) {
       return new Label(
          {name: label.name},
-         label.number,
-         label.repo_name,
+         ghIssue.number,
+         repoName,
          label.user,
          label.created_at
       );

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -259,7 +259,7 @@ function getLabelsFromEvents(events, ghIssue, repoName) {
 
    // Get a list of the most recent events for each label.
    labels = _.map(labels, function(events) {
-      events = _.sortBy(events, 'time');
+      events = _.sortBy(events, 'created_at');
       return _.last(events);
    });
 

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -32,7 +32,7 @@ api.getIssueEvents         = denodeify(github.issues.getEvents);
 // "issue" comments are the comments on the pull (issue) itself.
 api.getIssueComments       = denodeify(github.issues.getComments);
 // "review" comments are the comments on the diff of the pull
-var getPullReviewComments  = denodeify(github.pullRequests.getComments);
+api.getPullReviewComments  = denodeify(github.pullRequests.getComments);
 var getCommit              = denodeify(github.repos.getCommits);
 var getCommitStatus        = denodeify(github.statuses.get);
 var getNextPage            = denodeify(github.getNextPage.bind(github));
@@ -110,7 +110,7 @@ module.exports = {
       // before errors happen.
       githubPull.body = githubPull.body || '';
 
-      var reviewComments = module.exports.getPullReviewComments(githubPull.number);
+      var reviewComments = getPullReviewComments(githubPull.number);
       var comments = getIssueComments(githubPull.number);
       var headCommit = module.exports.getCommit(githubPull.head.sha);
       var commitStatus = module.exports.getCommitStatus(githubPull.head.sha);
@@ -178,12 +178,6 @@ module.exports = {
          var pull = new Pull(githubPull, signatures, comments, status, labels);
          return pull.syncToIssue();
       });
-   },
-
-   getPullReviewComments: function(pullNumber) {
-      return getPullReviewComments(params({
-         number: pullNumber
-      })).then(getAllPages);
    },
 
    getCommit: function(sha) {
@@ -304,6 +298,12 @@ function getIssueEvents(issueNumber) {
 function getIssueComments(issueNumber) {
    return api.getIssueComments(params({
       number: issueNumber
+   })).then(getAllPages);
+}
+
+function getPullReviewComments(pullNumber) {
+   return api.getPullReviewComments(params({
+      number: pullNumber
    })).then(getAllPages);
 }
 

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -93,7 +93,9 @@ module.exports = {
     */
    getOpenIssues: function() {
       debug("Getting open issues");
-      return getAllIssues(params()).then(getAllPages);
+      return getAllIssues(params())
+      .then(getAllPages)
+      .then(filterOutPulls);
    },
 
    /**
@@ -105,7 +107,8 @@ module.exports = {
       debug("Getting all issues");
       return getAllIssues(params({
          state:      'all'
-      })).then(getAllPages);
+      })).then(getAllPages)
+      .then(filterOutPulls);
    },
 
    /**
@@ -345,4 +348,16 @@ function getCommitStatus(sha) {
          }
       });
    });
+}
+
+/**
+ * Remove all entries that have the pull_request key set to something truthy
+ */
+function filterOutPulls(issues) {
+   debug("Filtering out pulls from list of %s issues", issues.length);
+   issues = _.filter(issues, function(issue) {
+      return !issue.pull_request || !issue.pull_request.url;
+   });
+   debug("Filtered down to %s issues", issues.length);
+   return issues;
 }

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -126,16 +126,24 @@ module.exports = {
       var headCommit = getCommit(githubPull.head.sha);
       var commitStatus = getCommitStatus(githubPull.head.sha);
       var events = getIssueEvents(githubPull.number);
+      // Only so we have the canonical list of labels.
+      var ghIssue = module.exports.getIssue(githubPull.number);
 
       // Returned to the map function. Each element of githubPulls maps to
       // a promise that resolves to a Pull.
-      return Promise.all([reviewComments, comments, headCommit, commitStatus, events])
+      return Promise.all([reviewComments,
+                          comments,
+                          headCommit,
+                          commitStatus,
+                          events,
+                          ghIssue])
        .then(function(results) {
          var reviewComments = results[0],
              comments       = results[1],
              headCommit     = results[2],
              commitStatus   = results[3],
-             events         = results[4];
+             events         = results[4],
+             ghIssue        = results[5];
 
          // Array of Signature objects.
          var signatures = comments.reduce(function(sigs, comment) {
@@ -184,7 +192,7 @@ module.exports = {
          }
 
          // Array of Label objects.
-         var labels = getLabelsFromEvents(events, githubPull, githubPull.base.repo.name);
+         var labels = getLabelsFromEvents(events, ghIssue, githubPull.base.repo.name);
 
          var pull = new Pull(githubPull, signatures, comments, status, labels);
          return pull.syncToIssue();

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -173,10 +173,26 @@ module.exports = {
          }
 
          // Array of Label objects.
-         var labels = getLabelsFromEvents(events, githubPull);
+         var labels = getLabelsFromEvents(events, githubPull, githubPull.base.repo.name);
 
          var pull = new Pull(githubPull, signatures, comments, status, labels);
          return pull.syncToIssue();
+      });
+   },
+
+   /**
+    * Takes a GitHub issue API response
+    * parses it, and returns a promise that resolves to an Issue object.
+    */
+   parseIssue: function(ghIssue) {
+      return getIssueEvents(ghIssue.number)
+      .then(function(events) {
+         // Array of Label objects.
+         // Note: using the repo name from the config for now until we support
+         // multiple repos. The ghIssue object doesn't contain the repo name.
+         var labels = getLabelsFromEvents(events, ghIssue, config.repo.name);
+
+         return new Issue.getFromGH(ghIssue, labels);
       });
    },
 };
@@ -202,9 +218,9 @@ function getAllPages(currentPage, allResults) {
 }
 
 /**
- * Get array of Label objects from complete list of a Pull Request's events.
+ * Get array of Label objects from complete list of a Issue's events.
  */
-function getLabelsFromEvents(events, githubPull) {
+function getLabelsFromEvents(events, ghIssue, repoName) {
    // Narrow list to relevant labeled/unlabeled events.
    events = _.filter(events, function(event) {
       return event.event === 'labeled' || event.event === 'unlabeled';
@@ -215,8 +231,8 @@ function getLabelsFromEvents(events, githubPull) {
       return {
          type: event.event,
          name: event.label.name,
-         number: githubPull.number,
-         repo_name: githubPull.base.repo.name,
+         number: ghIssue.number,
+         repo_name: repoName,
          user: event.actor.login,
          created_at: new Date(event.created_at)
       };

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -34,7 +34,7 @@ api.getIssueComments       = denodeify(github.issues.getComments);
 // "review" comments are the comments on the diff of the pull
 api.getPullReviewComments  = denodeify(github.pullRequests.getComments);
 api.getCommit              = denodeify(github.repos.getCommits);
-var getCommitStatus        = denodeify(github.statuses.get);
+api.getCommitStatus        = denodeify(github.statuses.get);
 var getNextPage            = denodeify(github.getNextPage.bind(github));
 
 module.exports = {
@@ -113,7 +113,7 @@ module.exports = {
       var reviewComments = getPullReviewComments(githubPull.number);
       var comments = getIssueComments(githubPull.number);
       var headCommit = getCommit(githubPull.head.sha);
-      var commitStatus = module.exports.getCommitStatus(githubPull.head.sha);
+      var commitStatus = getCommitStatus(githubPull.head.sha);
       var events = getIssueEvents(githubPull.number);
 
       // Returned to the map function. Each element of githubPulls maps to
@@ -177,20 +177,6 @@ module.exports = {
 
          var pull = new Pull(githubPull, signatures, comments, status, labels);
          return pull.syncToIssue();
-      });
-   },
-
-   getCommitStatus: function(sha) {
-      return new Promise(function(resolve, reject) {
-         getCommitStatus(params({
-            sha: sha
-         })).then(function(status) {
-            if (status.length) {
-               resolve(status[0]);
-            } else {
-               resolve(null);
-            }
-         });
       });
    },
 };
@@ -303,6 +289,20 @@ function getCommit(sha) {
             resolve(commits[0]);
          } else {
             return reject();
+         }
+      });
+   });
+}
+
+function getCommitStatus(sha) {
+   return new Promise(function(resolve, reject) {
+      api.getCommitStatus(params({
+         sha: sha
+      })).then(function(status) {
+         if (status.length) {
+            resolve(status[0]);
+         } else {
+            resolve(null);
          }
       });
    });

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -6,6 +6,7 @@ var GithubApi = require('github'),
       debug: config.debug,
       version: '3.0.0'
     }),
+    debug = require('debug')('pulldasher:github'),
     Pull = require('../models/pull'),
     Issue = require('../models/issue'),
     Comment = require('../models/comment'),
@@ -45,6 +46,7 @@ module.exports = {
     * a query for a particular Pull Request.
     */
    getPull: function(number) {
+      debug("Getting pull %s", number);
       return getPull(params({
          number:     number
       }));
@@ -56,6 +58,7 @@ module.exports = {
     * Returns a promise which resolves to an array of all open pull requests
     */
    getOpenPulls: function() {
+      debug("Getting open pulls");
       return getAllPulls(params()).then(getAllPages);
    },
 
@@ -65,6 +68,7 @@ module.exports = {
     * Returns a promise which resolves to an array of all pull requests
     */
    getAllPulls: function() {
+      debug("Getting all pulls");
       return getAllPulls(params({
          state:      'all'
       })).then(getAllPages);
@@ -76,6 +80,7 @@ module.exports = {
     * Returns a promise which resolves to a github issue
     */
    getIssue: function(number) {
+      debug("Getting issue %s", number);
       return getIssue(params({
          number: number
       }));
@@ -87,6 +92,7 @@ module.exports = {
     * Returns a promise which resolves to an array of all open issues
     */
    getOpenIssues: function() {
+      debug("Getting open issues");
       return getAllIssues(params()).then(getAllPages);
    },
 
@@ -96,6 +102,7 @@ module.exports = {
     * Returns a promise which resolves to an array of all issues
     */
    getAllIssues: function() {
+      debug("Getting all issues");
       return getAllIssues(params({
          state:      'all'
       })).then(getAllPages);
@@ -106,6 +113,7 @@ module.exports = {
     * parses it, and returns a promise that resolves to a Pull objects.
     */
    parse: function(githubPull) {
+      debug("Getting all information for pull %s", githubPull.number);
       // We've occasionally noticed a null pull body, so lets fix it upfront
       // before errors happen.
       githubPull.body = githubPull.body || '';
@@ -185,6 +193,7 @@ module.exports = {
     * parses it, and returns a promise that resolves to an Issue object.
     */
    parseIssue: function(ghIssue) {
+      debug("Getting all information for issue %s", ghIssue.number);
       return getIssueEvents(ghIssue.number)
       .then(function(events) {
          // Array of Label objects.
@@ -203,11 +212,13 @@ module.exports = {
  * results.
  */
 function getAllPages(currentPage, allResults) {
+   debug("Got %s results", currentPage.length);
    return new Promise(function (resolve, reject) {
       allResults = allResults || [];
       allResults.push(currentPage);
 
       if (!github.hasNextPage(currentPage)) {
+         debug("No more results");
          return resolve(_.flatten(allResults));
       }
 
@@ -221,10 +232,15 @@ function getAllPages(currentPage, allResults) {
  * Get array of Label objects from complete list of a Issue's events.
  */
 function getLabelsFromEvents(events, ghIssue, repoName) {
+   debug("Extracting label assignments from %s issue events for #%s",
+    events.length, ghIssue.number);
+
    // Narrow list to relevant labeled/unlabeled events.
    events = _.filter(events, function(event) {
       return event.event === 'labeled' || event.event === 'unlabeled';
    });
+
+   debug("Found %s label events for #%s", events.length, ghIssue.number);
 
    // Build simple Event objects with all the info we care about.
    events = events.map(function(event) {
@@ -250,6 +266,8 @@ function getLabelsFromEvents(events, ghIssue, repoName) {
    labels = _.filter(labels, function(event) {
       return event.type === 'labeled';
    });
+
+   debug("Found %s unique labels for #%s", labels.length, ghIssue.number);
 
    // Construct Label objects.
    return labels.map(function(label) {
@@ -278,18 +296,21 @@ function params(apiParams) {
  * Return a promise for all issue events for the given issue / pull
  */
 function getIssueEvents(issueNumber) {
+   debug("Getting events for issue #%s", issueNumber);
    return api.getIssueEvents(params({
       number: issueNumber
    })).then(getAllPages);
 }
 
 function getIssueComments(issueNumber) {
+   debug("Getting comments for issue #%s", issueNumber);
    return api.getIssueComments(params({
       number: issueNumber
    })).then(getAllPages);
 }
 
 function getPullReviewComments(pullNumber) {
+   debug("Getting pull review comments for pull #%s", pullNumber);
    return api.getPullReviewComments(params({
       number: pullNumber
    })).then(getAllPages);
@@ -297,6 +318,7 @@ function getPullReviewComments(pullNumber) {
 
 function getCommit(sha) {
    return new Promise(function (resolve, reject){
+      debug("Getting commit %s", sha);
       api.getCommit(params({
          sha: sha,
          per_page: 1
@@ -312,6 +334,7 @@ function getCommit(sha) {
 
 function getCommitStatus(sha) {
    return new Promise(function(resolve, reject) {
+      debug("Getting commit status for %s", sha);
       api.getCommitStatus(params({
          sha: sha
       })).then(function(status) {

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -30,7 +30,7 @@ var getIssue               = denodeify(github.issues.getRepoIssue);
 var getAllIssues           = denodeify(github.issues.repoIssues);
 api.getIssueEvents         = denodeify(github.issues.getEvents);
 // "issue" comments are the comments on the pull (issue) itself.
-var getPullComments        = denodeify(github.issues.getComments);
+api.getIssueComments       = denodeify(github.issues.getComments);
 // "review" comments are the comments on the diff of the pull
 var getPullReviewComments  = denodeify(github.pullRequests.getComments);
 var getCommit              = denodeify(github.repos.getCommits);
@@ -111,7 +111,7 @@ module.exports = {
       githubPull.body = githubPull.body || '';
 
       var reviewComments = module.exports.getPullReviewComments(githubPull.number);
-      var comments = module.exports.getPullComments(githubPull.number);
+      var comments = getIssueComments(githubPull.number);
       var headCommit = module.exports.getCommit(githubPull.head.sha);
       var commitStatus = module.exports.getCommitStatus(githubPull.head.sha);
       var events = getIssueEvents(githubPull.number);
@@ -178,12 +178,6 @@ module.exports = {
          var pull = new Pull(githubPull, signatures, comments, status, labels);
          return pull.syncToIssue();
       });
-   },
-
-   getPullComments: function(pullNumber) {
-      return getPullComments(params({
-         number: pullNumber
-      })).then(getAllPages);
    },
 
    getPullReviewComments: function(pullNumber) {
@@ -306,3 +300,10 @@ function getIssueEvents(issueNumber) {
       number: issueNumber
    })).then(getAllPages);
 }
+
+function getIssueComments(issueNumber) {
+   return api.getIssueComments(params({
+      number: issueNumber
+   })).then(getAllPages);
+}
+

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -89,7 +89,8 @@ issueQueue.pop(function(githubIssue, next) {
    // Allow callers to push functions on the queue to signal when an item has
    // made it through
    if (typeof githubIssue === 'function') {
-      return githubIssue();
+      githubIssue();
+      return next();
    }
    debug("refreshing issue %s", githubIssue.number);
    gitManager.parseIssue(githubIssue)
@@ -104,7 +105,8 @@ pullQueue.pop(function(githubPull, next) {
    // Allow callers to push functions on the queue to signal when an item has
    // made it through
    if (typeof githubPull === 'function') {
-      return githubPull();
+      githubPull();
+      return next();
    }
    debug("refreshing pull %s", githubPull.number);
    gitManager.parse(githubPull)

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -92,8 +92,8 @@ issueQueue.pop(function(githubIssue, next) {
       return githubIssue();
    }
    debug("refreshing issue %s", githubIssue.number);
-   Issue.getFromGH(githubIssue)
-   .then(dbManager.updateIssue)
+   gitManager.parseIssue(githubIssue)
+   .then(dbManager.updateAllIssueData)
    .done(function() {
       debug("done refreshing issue %s", githubIssue.number);
       next();

--- a/migrations/0004-issues--rename-some-columns.sql
+++ b/migrations/0004-issues--rename-some-columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `issues`
+CHANGE COLUMN `dateCreated`        `date_closed`      int(11) DEFAULT NULL,
+CHANGE COLUMN `dateClosed`         `date_created`     int(11) DEFAULT NULL;

--- a/migrations/0005-issues--rename-milestone_due_date.sql
+++ b/migrations/0005-issues--rename-milestone_due_date.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `issues`
+CHANGE COLUMN `milestone_due_date` `milestone_due_on` int(11) DEFAULT NULL;

--- a/models/db_issue.js
+++ b/models/db_issue.js
@@ -10,14 +10,9 @@ function DBIssue(issue) {
       assignee: issue.assignee,
       status: issue.status,
       date_created: utils.toUnixTime(issue.date_created),
-      date_closed: utils.toUnixTime(issue.date_closed)
+      date_closed: utils.toUnixTime(issue.date_closed),
+      difficulty: issue.difficulty
    };
-
-   if (issue.difficulty) {
-      this.data.difficulty = extractInt(issue.difficulty);
-   } else {
-      this.data.difficulty = null;
-   }
 
    if (issue.milestone) {
       this.data.milestone_title = issue.milestone.title;
@@ -46,10 +41,5 @@ DBIssue.prototype.save = function() {
 
    return db.query(q_update, issueData);
 };
-
-function extractInt(str) {
-   var result = str && str.match(/[0-9]+/);
-   return result ? parseInt(result[0], 10) : null;
-}
 
 module.exports = DBIssue;

--- a/models/db_issue.js
+++ b/models/db_issue.js
@@ -21,10 +21,10 @@ function DBIssue(issue) {
 
    if (issue.milestone) {
       this.data.milestone_title = issue.milestone.title;
-      this.data.milestone_due_date = utils.toUnixTime(issue.milestone.dueDate);
+      this.data.milestone_due_on = utils.toUnixTime(issue.milestone.due_on);
    } else {
       this.data.milestone_title = null;
-      this.data.milestone_due_date = null;
+      this.data.milestone_due_on = null;
    }
 }
 

--- a/models/db_issue.js
+++ b/models/db_issue.js
@@ -9,8 +9,8 @@ function DBIssue(issue) {
       title: issue.title,
       assignee: issue.assignee,
       status: issue.status,
-      dateCreated: utils.toUnixTime(issue.dateCreated),
-      dateClosed: utils.toUnixTime(issue.dateClosed)
+      date_created: utils.toUnixTime(issue.date_created),
+      date_closed: utils.toUnixTime(issue.date_closed)
    };
 
    if (issue.difficulty) {

--- a/models/issue.js
+++ b/models/issue.js
@@ -46,8 +46,8 @@ Issue.getFromGH = function(data) {
       number: data.number,
       title: data.title,
       status: data.state,
-      dateCreated: new Date(data.created_at),
-      dateClosed: new Date(data.closed_at),
+      date_created: new Date(data.created_at),
+      date_closed: new Date(data.closed_at),
       milestone: data.milestone ? {
          title: data.milestone.title,
          dueDate: new Date(data.milestone.due_on)
@@ -67,8 +67,8 @@ Issue.getFromDB = function(data) {
       number: data.number,
       title: data.title,
       status: data.state,
-      dateCreated: utils.fromUnixTime(data.dateCreated),
-      dateClosed: utils.fromUnixTime(data.dateClosed),
+      date_created: utils.fromUnixTime(data.date_created),
+      date_closed: utils.fromUnixTime(data.date_closed),
       milestone: data.milestone_title ? {
          title: data.milestone_title,
          dueDate: utils.fromUnixTime(data.milestone_due_on)

--- a/models/issue.js
+++ b/models/issue.js
@@ -6,7 +6,8 @@ var Promise = require('promise');
 var DBIssue = require('./db_issue');
 
 /**
- * Create a new issue.
+ * Create a new issue. Not meant to be used directly, see
+ * Issue.getFromGH or Issue.findByNumber
  */
 function Issue(data) {
    _.extend(this, data);
@@ -41,7 +42,7 @@ Issue.prototype.updateFromLabels = function(labels) {
  * A factory method to create an issue from GitHub data. Currently, the data
  * in Issue is almost identical to the data coming from GitHub.
  */
-Issue.getFromGH = function(data) {
+Issue.getFromGH = function(data, labels) {
    var issueData = {
       number: data.number,
       title: data.title,
@@ -52,10 +53,11 @@ Issue.getFromGH = function(data) {
          title: data.milestone.title,
          due_on: new Date(data.milestone.due_on)
       } : null,
-      assignee: data.assignee ? data.assignee.login : null
+      assignee: data.assignee ? data.assignee.login : null,
+      labels: labels || []
    };
    var issue = new Issue(issueData);
-   issue.updateFromLabels(data.labels);
+   issue.updateFromLabels(labels | []);
    return Promise.resolve(issue);
 };
 

--- a/models/issue.js
+++ b/models/issue.js
@@ -77,7 +77,7 @@ Issue.getFromDB = function(data, labels) {
    var issueData = {
       number: data.number,
       title: data.title,
-      status: data.state,
+      status: data.status,
       date_created: utils.fromUnixTime(data.date_created),
       date_closed: utils.fromUnixTime(data.date_closed),
       milestone: data.milestone_title ? {

--- a/models/issue.js
+++ b/models/issue.js
@@ -25,17 +25,20 @@ function Issue(data, labels) {
 Issue.prototype.updateFromLabels = function(labels) {
    var self = this;
    if (labels) {
+      log("Processing %s labels on #%s", labels.length, self.number);
       (config.labels || []).forEach(function(labelConfig) {
          self[labelConfig.name] = null;
          labels.forEach(function(label) {
-            if (labelConfig.regex.test(label.name)) {
+            var labelName = label.data.title;
+            log("Testing label '%s' against regex %s", labelName, labelConfig.regex);
+            if (labelConfig.regex.test(labelName)) {
                log("Setting %s on #%s because of a label reading %s",
-                labelConfig.name, self.number, label.name);
+                labelConfig.name, self.number, labelName);
 
                if (labelConfig.process) {
-                  self[labelConfig.name] = labelConfig.process(label.name);
+                  self[labelConfig.name] = labelConfig.process(labelName);
                } else {
-                  self[labelConfig.name] = label.name;
+                  self[labelConfig.name] = labelName;
                }
             }
          });

--- a/models/issue.js
+++ b/models/issue.js
@@ -50,7 +50,7 @@ Issue.getFromGH = function(data) {
       date_closed: new Date(data.closed_at),
       milestone: data.milestone ? {
          title: data.milestone.title,
-         dueDate: new Date(data.milestone.due_on)
+         due_on: new Date(data.milestone.due_on)
       } : null,
       assignee: data.assignee ? data.assignee.login : null
    };
@@ -71,7 +71,7 @@ Issue.getFromDB = function(data) {
       date_closed: utils.fromUnixTime(data.date_closed),
       milestone: data.milestone_title ? {
          title: data.milestone_title,
-         dueDate: utils.fromUnixTime(data.milestone_due_on)
+         due_on: utils.fromUnixTime(data.milestone_due_on)
       } : null,
       difficulty: data.difficulty,
       assignee: data.assignee

--- a/models/label.js
+++ b/models/label.js
@@ -9,7 +9,7 @@ function Label(data, pullNumber, repoName, user, created_at) {
       number: pullNumber,
       repo_name: repoName,
       user: user,
-      created_at: new Date(created_at)
+      created_at: created_at && new Date(created_at)
    };
 }
 

--- a/models/pull.js
+++ b/models/pull.js
@@ -85,7 +85,7 @@ Pull.prototype.syncToIssue = function() {
          if (issue.milestone) {
             var milestone = self.data.milestone;
             milestone.title = issue.milestone.title;
-            milestone.dueDate = issue.milestone.dueDate;
+            milestone.due_on = issue.milestone.due_on;
          }
          self.data.difficulty = issue.difficulty;
          return self.update();

--- a/schema.sql
+++ b/schema.sql
@@ -61,7 +61,7 @@ CREATE TABLE `issues` (
   `title` varchar(255) DEFAULT NULL,
   `difficulty` int(10) DEFAULT NULL,
   `milestone_title` varchar(255) DEFAULT NULL,
-  `milestone_due_date` int(11) DEFAULT NULL,
+  `milestone_due_on` int(11) DEFAULT NULL,
   `assignee` varchar(255) DEFAULT NULL,
   `status` varchar(30) DEFAULT NULL,
   `date_created` int(11) DEFAULT NULL,

--- a/schema.sql
+++ b/schema.sql
@@ -64,8 +64,8 @@ CREATE TABLE `issues` (
   `milestone_due_date` int(11) DEFAULT NULL,
   `assignee` varchar(255) DEFAULT NULL,
   `status` varchar(30) DEFAULT NULL,
-  `dateCreated` int(11) DEFAULT NULL,
-  `dateClosed` int(11) DEFAULT NULL,
+  `date_created` int(11) DEFAULT NULL,
+  `date_closed` int(11) DEFAULT NULL,
   PRIMARY KEY (`number`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
There are a few other semi-related things in here too:

* Record labels on issue events like *labeled* and *unlabeled*
* Record labels upon refreshing an issue
* Move some git-manager.js functions out of exports
* Change the column names in the issues table to be consistent with the
  pulls table

Closes #42