### PR TITLE
Dates: deal with null values

### DIFF
--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -7,6 +7,7 @@ var GithubApi = require('github'),
       version: '3.0.0'
     }),
     debug = require('debug')('pulldasher:github'),
+    utils = require('./utils'),
     Pull = require('../models/pull'),
     Comment = require('../models/comment'),
     Label = require('../models/label'),
@@ -258,7 +259,7 @@ function getLabelsFromEvents(events, ghIssue, repoName) {
          type: event.event,
          name: event.label.name,
          user: event.actor.login,
-         created_at: new Date(event.created_at)
+         created_at: utils.fromDateString(event.created_at)
       };
    });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,5 +13,13 @@ module.exports = {
     */
    fromUnixTime: function(t) {
       return (typeof t) === 'number' ? new Date(t * 1000) : t;
-   }
+   },
+
+   /**
+    * Converts `str` to a Date object from a Date string (or null).
+    * Returns null if str is falsy.
+    */
+   fromDateString: function(str) {
+      return str ? new Date(str) : null;
+   },
 };

--- a/migrations/0006-date-columns--null-out-zeros.sql
+++ b/migrations/0006-date-columns--null-out-zeros.sql
@@ -1,0 +1,47 @@
+UPDATE `comments`
+SET `date` = NULL
+WHERE `date` = 0;
+
+--
+
+UPDATE `issues`
+SET `milestone_due_on` = NULL
+WHERE `milestone_due_on` = 0;
+
+UPDATE `issues`
+SET `date_created` = NULL
+WHERE `date_created` = 0;
+
+UPDATE `issues`
+SET `date_closed` = NULL
+WHERE `date_closed` = 0;
+
+--
+
+UPDATE `pull_labels`
+SET `date` = NULL
+WHERE `date` = 0;
+
+--
+
+UPDATE `pull_signatures`
+SET `date` = NULL
+WHERE `date` = 0;
+
+--
+
+UPDATE `pulls`
+SET `date_updated` = NULL
+WHERE `date_updated` = 0;
+
+UPDATE `pulls`
+SET `date_closed` = NULL
+WHERE `date_closed` = 0;
+
+UPDATE `pulls`
+SET `date_merged` = NULL
+WHERE `date_merged` = 0;
+
+UPDATE `pulls`
+SET `milestone_due_on` = NULL
+WHERE `milestone_due_on` = 0;

--- a/models/issue.js
+++ b/models/issue.js
@@ -58,7 +58,7 @@ Issue.getFromGH = function(data, labels) {
       title: data.title,
       status: data.state,
       date_created: new Date(data.created_at),
-      date_closed: new Date(data.closed_at),
+      date_closed: utils.fromDateString(data.closed_at),
       milestone: data.milestone ? {
          title: data.milestone.title,
          due_on: new Date(data.milestone.due_on)

--- a/models/label.js
+++ b/models/label.js
@@ -9,7 +9,7 @@ function Label(data, pullNumber, repoName, user, created_at) {
       number: pullNumber,
       repo_name: repoName,
       user: user,
-      created_at: created_at && new Date(created_at)
+      created_at: utils.fromDateString(created_at)
    };
 }
 

--- a/models/pull.js
+++ b/models/pull.js
@@ -13,15 +13,14 @@ function Pull(data, signatures, comments, commitStatus, labels) {
       state: data.state,
       title: data.title,
       body: data.body,
-      created_at: new Date(data.created_at),
-      updated_at: new Date(data.updated_at),
-      closed_at: new Date(data.closed_at),
-      merged_at: new Date(data.merged_at),
+      created_at: utils.fromDateString(data.created_at),
+      updated_at: utils.fromDateString(data.updated_at),
+      closed_at: utils.fromDateString(data.closed_at),
+      merged_at: utils.fromDateString(data.merged_at),
       difficulty: data.difficulty,
       milestone: {
          title: data.milestone && data.milestone.title,
-         due_on: data.milestone && data.milestone.due_on ?
-          new Date(data.milestone.due_on) : null,
+         due_on: data.milestone && utils.fromDateString(data.milestone.due_on)
       },
       head: {
          ref: data.head.ref,

--- a/models/signature.js
+++ b/models/signature.js
@@ -12,7 +12,7 @@ function Signature(data) {
          login:         data.user.login
       },
       type:             data.type,
-      created_at:       new Date(data.created_at),
+      created_at:       utils.fromDateString(data.created_at),
       active:           data.active,
       comment_id:       data.comment_id
    };


### PR DESCRIPTION
Previously every missing or null date field (from the github api)
would end up as 0 in the database instead of NULL because
we were always doing `new Date(thing.date)`.

I've extracted the most likely behavior into a utils function
and used it wherever it made sense. This was nearly everyplace besides
the client and places where we were explicitly comparing Date objects.

Closes #47