### PR TITLE
Fix null error in jshint grunt plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,8 @@ module.exports = function(grunt) {
         unused: 'vars',
         // Deprecated relaxers
         sub: true,
-        multistr: true
+        multistr: true,
+        reporterOutput: ""
       },
       gruntfile: {
         src: 'Gruntfile.js'


### PR DESCRIPTION
An issue was filed on jshint's github about this
https://github.com/jshint/jshint/issues/2922. The solution seems to be to
explicitly define a reporterOutput option with a value of empty string.

After making this change, grunt builds ran flawlessly.