### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:latest
+
+RUN mkdir -p /opt/pulldasher
+WORKDIR /opt/pulldasher
+
+# Install dependencies
+COPY package.json /opt/pulldasher
+RUN npm install
+
+COPY . /opt/pulldasher
+
+RUN npm install -g bower grunt-cli
+RUN bower install --allow-root
+
+# This makes the bootstrapcdn link the font path, instead of loading it locally.
+RUN sed -i -e "/^@fa-font-path/d" bower_components/font-awesome/less/variables.less
+RUN sed -i -e "s/\/\/@fa-font-path/@fa-font-path/" bower_components/font-awesome/less/variables.less
+
+RUN grunt
+
+EXPOSE 8080
+CMD ["bin/pulldasher"]


### PR DESCRIPTION
This adds a Dockerfile that allows running pulldasher in a docker
container. The container does not include an instance of mysqld, so the
pulldasher container will not be able to use a connection to mysql using
localhost. It will have to be able to connect to a mysqld server running
in either another container, or another ip address.