### PR TITLE
/fonts path: serve the correct directory

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ app.use("/public", express.static(__dirname + '/public'));
 app.use("/spec", express.static(__dirname + '/views/current/spec'));
 app.use("/css", express.static(__dirname + '/views/current/css'));
 app.use("/html", express.static(__dirname + '/views/current/html'));
-app.use("/fonts", express.static(__dirname + '/bower_components/bootstrap/dist/fonts'));
+app.use("/fonts", express.static(__dirname + '/bower_components/font-awesome/fonts'));
 app.use("/lib", express.static(__dirname + '/bower_components'));
 app.use(partials());
 app.use(express.urlencoded());


### PR DESCRIPTION
The only fonts we use are the font-awesome ones where are not present
in the bootstrap fonts dir. It seems we dont' use the bootstrap glyph
fonts at all so it's Ok to change this dir.

Before, we were getting a 404 when looking for font-awesome files in
the /fonts dir. After, they exist!

Closes #55