### PR TITLE
Hooks: deal with issue events about pull requests

### DIFF
--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -122,7 +122,11 @@ function handleIssueEvent(body) {
       case "opened":
          // Always do this for opened issues because a full refresh
          // is the easiest way to get *who* assigned the initial labels.
-         return refreshPullOrIssue(body);
+         return doneHandling.then(function() {
+            // Not returning here cause we don't want to delay replying to the
+            // hook with a 200 since we know what needs to be done.
+            refreshPullOrIssue(body);
+         });
 
       case "reopened":
       case "closed":

--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -101,11 +101,7 @@ var HooksController = {
             // delete or update any signatures tied to that comment, then
             // delete all signatures and re-insert in order them so the
             // dev_blocking and such comes out correct.
-            if (body.issue.pull_request) {
-               refresh.pull(body.issue.number);
-            } else {
-               refresh.issue(body.issue.number);
-            }
+            refreshPullOrIssue(body);
          }
       } else if (event === 'pull_request_review_comment') {
          if (body.action === 'deleted') {
@@ -190,6 +186,16 @@ function reprocessLabels(issueNumber, repo) {
    debug("Reprocessing labels for Issue #%s", issueNumber);
    return dbManager.getIssue(issueNumber, repo)
    .then(dbManager.updateIssue);
+}
+
+function refreshPullOrIssue(responseBody) {
+   // The Docs: https://developer.github.com/v3/issues/#list-issues say you can
+   // tell the difference like this:
+   if (responseBody.issue.pull_request) {
+      refresh.pull(responseBody.issue.number);
+   } else {
+      refresh.issue(responseBody.issue.number);
+   }
 }
 
 module.exports = HooksController;

--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -51,8 +51,8 @@ var HooksController = {
                preUpdate = dbManager.insertLabel(
                   new Label(
                      body.label,
-                     body.number,
-                     body.pull_request.head.repo.name,
+                     body.pull_request.number,
+                     body.repository.name,
                      body.sender.login,
                      body.pull_request.updated_at
                   )
@@ -62,8 +62,8 @@ var HooksController = {
                preUpdate = dbManager.deleteLabel(
                   new Label(
                      body.label,
-                     body.number,
-                     body.pull_request.head.repo.name
+                     body.pull_request.number,
+                     body.repository.name
                   )
                );
                break;


### PR DESCRIPTION
We've seen this in practice and the docs mention it; we can receive
issue events about pull requests. Thankfully they also mention how to
distiguish them. Previously, we didn't and would occasionally get
issues records created for pull requests (instead of records in the
pulls table).

CC @entendu

Note: there are a few other small refactorings in here too, go
commit by commit for CR.

Closes #57