### PR TITLE
Github API Responses: don't depend on user.login

### DIFF
--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -8,6 +8,7 @@ var config     = require('../config'),
     Comment    = require('../models/comment'),
     Label      = require('../models/label'),
     refresh    = require('../lib/refresh'),
+    getLogin   = require('../lib/get-user-login'),
     dbManager  = require('../lib/db-manager');
 
 var HooksController = {
@@ -170,7 +171,7 @@ function handleLabelEvents(body) {
             body.label,
             object.number,
             body.repository.name,
-            body.sender.login,
+            getLogin(body.sender),
             object.updated_at
          ));
 

--- a/lib/get-user-id.js
+++ b/lib/get-user-id.js
@@ -1,0 +1,7 @@
+module.exports = function(userApiObject) {
+   // 10137 is the userid of the "ghost" user
+   // https://api.github.com/users/ghost
+   // All deleted users are replaced with references to this user within github
+   // (except in the api, where they are just null
+   return userApiObject ? userApiObject.id : 10137;
+}

--- a/lib/get-user-login.js
+++ b/lib/get-user-login.js
@@ -1,0 +1,3 @@
+module.exports = function(userApiObject) {
+   return userApiObject ? userApiObject.login : "deleted user";
+}

--- a/lib/get-user-login.js
+++ b/lib/get-user-login.js
@@ -1,3 +1,6 @@
 module.exports = function(userApiObject) {
-   return userApiObject ? userApiObject.login : "deleted user";
+   // All deleted users are replaced with references to this user within
+   // the github web app (except in the api, where they are just null).
+   // https://github.com/ghost
+   return userApiObject ? userApiObject.login : "ghost";
 }

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -14,6 +14,7 @@ var GithubApi = require('github'),
     Label = require('../models/label'),
     Status = require('../models/status'),
     Signature = require('../models/signature'),
+    getLogin  = require('./get-user-login'),
     rateLimit = require('./rate-limit.js');
 
 github.authenticate({
@@ -259,7 +260,7 @@ function getLabelsFromEvents(events, ghIssue, repoName) {
       return {
          type: event.event,
          name: event.label.name,
-         user: event.actor.login,
+         user: getLogin(event.actor),
          created_at: utils.fromDateString(event.created_at)
       };
    });

--- a/models/comment.js
+++ b/models/comment.js
@@ -1,4 +1,5 @@
 var utils = require('../lib/utils');
+var getLogin = require('../lib/get-user-login');
 
 /**
  * A Pull Request comment.
@@ -8,7 +9,7 @@ function Comment(data) {
       number:        data.number,
       repo:          data.repo,
       user: {
-         login: data.user.login
+         login: getLogin(data.user)
       },
       created_at:    new Date(data.created_at),
       comment_type:  data.type,

--- a/models/db_comment.js
+++ b/models/db_comment.js
@@ -1,5 +1,6 @@
 var utils = require('../lib/utils'),
     db = require('../lib/db'),
+    getLogin = require('../lib/get-user-login'),
     debug = require('debug')('pulldasher:db_comment');
 
 /**
@@ -11,7 +12,7 @@ function DBComment(comment) {
    this.data = {
       number:     commentData.number,
       repo_name:  commentData.repo,
-      user:       commentData.user.login,
+      user:       getLogin(commentData.user),
       date:       utils.toUnixTime(commentData.created_at),
       comment_type: commentData.comment_type,
       comment_id: commentData.comment_id

--- a/models/db_pull.js
+++ b/models/db_pull.js
@@ -1,4 +1,5 @@
 var utils = require('../lib/utils'),
+    getLogin = require('../lib/get-user-login'),
     db = require('../lib/db');
 
 // Builds an object representation of a row in the DB `pulls` table
@@ -22,7 +23,7 @@ function DBPull(pull) {
       repo_owner: pullData.head.repo.owner.login,
       repo_name: pullData.head.repo.name,
       base_branch: pullData.base.ref,
-      owner: pullData.user.login,
+      owner: getLogin(pullData.user),
       cr_req: pullData.cr_req,
       qa_req: pullData.qa_req,
       closes: pullData.closes,

--- a/models/db_signature.js
+++ b/models/db_signature.js
@@ -1,4 +1,5 @@
 var utils = require('../lib/utils'),
+    getLogin = require('../lib/get-user-login'),
     db = require('../lib/db');
 
 /**
@@ -9,7 +10,7 @@ function DBSignature(signature) {
    var sigData = signature.data;
    this.data = {
       number:     sigData.number,
-      user:       sigData.user.login,
+      user:       getLogin(sigData.user),
       userid:     sigData.user.id,
       type:       sigData.type,
       date:       utils.toUnixTime(sigData.created_at),

--- a/models/db_signature.js
+++ b/models/db_signature.js
@@ -1,5 +1,6 @@
 var utils = require('../lib/utils'),
     getLogin = require('../lib/get-user-login'),
+    getUserid = require('../lib/get-user-id'),
     db = require('../lib/db');
 
 /**
@@ -11,7 +12,7 @@ function DBSignature(signature) {
    this.data = {
       number:     sigData.number,
       user:       getLogin(sigData.user),
-      userid:     sigData.user.id,
+      userid:     getUserid(sigData.user),
       type:       sigData.type,
       date:       utils.toUnixTime(sigData.created_at),
       active:     sigData.active,

--- a/models/issue.js
+++ b/models/issue.js
@@ -3,6 +3,7 @@ var _       = require('underscore');
 var config  = require('../config');
 var log     = require('debug')('pulldasher:issue');
 var DBIssue = require('./db_issue');
+var getLogin = require('../lib/get-user-login');
 
 /**
  * Create a new issue. Not meant to be used directly, see
@@ -67,7 +68,7 @@ Issue.getFromGH = function(data, labels) {
          title: data.milestone.title,
          due_on: new Date(data.milestone.due_on)
       } : null,
-      assignee: data.assignee ? data.assignee.login : null,
+      assignee: getLogin(data.assignee),
       labels: labels || [],
    };
 

--- a/models/pull.js
+++ b/models/pull.js
@@ -5,6 +5,7 @@ var queue = require('../lib/pull-queue');
 var Promise = require('promise');
 var debug = require('debug')('pulldasher:pull');
 var DBPull = require('./db_pull');
+var getLogin = require('../lib/get-user-login');
 
 function Pull(data, signatures, comments, commitStatus, labels) {
    this.data = {
@@ -35,7 +36,7 @@ function Pull(data, signatures, comments, commitStatus, labels) {
          ref: data.base.ref
       },
       user: {
-         login: data.user.login
+         login: getLogin(data.user)
       }
    };
 

--- a/models/signature.js
+++ b/models/signature.js
@@ -1,4 +1,5 @@
 var config = require('../config'),
+    getLogin = require('../lib/get-user-login'),
     utils = require('../lib/utils');
 
 /**
@@ -9,7 +10,7 @@ function Signature(data) {
       number:           data.number,
       user: {
          id:            data.user.id,
-         login:         data.user.login
+         login:         getLogin(data.user)
       },
       type:             data.type,
       created_at:       utils.fromDateString(data.created_at),
@@ -30,7 +31,7 @@ Signature.parseComment = function parseComment(comment, pullNumber) {
             number: pullNumber,
             user: {
                id:    comment.user.id,
-               login: comment.user.login
+               login: getLogin(comment.user)
             },
             type: tag.name,
             created_at: comment.created_at,

--- a/models/signature.js
+++ b/models/signature.js
@@ -1,5 +1,6 @@
 var config = require('../config'),
     getLogin = require('../lib/get-user-login'),
+    getUserid = require('../lib/get-user-id'),
     utils = require('../lib/utils');
 
 /**
@@ -9,7 +10,7 @@ function Signature(data) {
    this.data = {
       number:           data.number,
       user: {
-         id:            data.user.id,
+         id:            getUserid(data.user),
          login:         getLogin(data.user)
       },
       type:             data.type,
@@ -30,7 +31,7 @@ Signature.parseComment = function parseComment(comment, pullNumber) {
          signatures.push(new Signature({
             number: pullNumber,
             user: {
-               id:    comment.user.id,
+               id:    getUserid(comment.user),
                login: getLogin(comment.user)
             },
             type: tag.name,


### PR DESCRIPTION
Sometimes github user accounts are deleted.
When they are included in an api response, the user looks like:

Normal User:

    issue: {
        user : {
            login: "danielbeardsley",
            url: ...
        }
    }

Deleted User:

    issue: {
        user : null
    }

This change wraps all places where we access properties of the user
object in an api response.

Most places would have previously crashed the app. The one that
changed now produces "ghost" instead of NULL (just like github's
web UI). This allows the DB columns to still be NOT NULL. Keeping them
from being null makes it so we don't have to deal with nulls in the
rest of our code.

Perhaps in the future we'll want to do something different, but
this is safe for now.

Note: I found these by:
git grep -E "\.(sender|actor|user|assignee)"

And looking at the backend files that matched. The frontend files
dont' have to change because they only deal with our model objects
that have been constructed from API responses (which now inject this
ghost user).

Closes #59