### PR TITLE
Handle passport authentication errors correctly

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -35,6 +35,11 @@ module.exports = {
       app.get('/auth/github/callback', function(req, res, next) {
          passport.authenticate('github',
          function(err, user, info) {
+            if (err) {
+               debug("Error: " + err);
+               next(err);
+            }
+
             debug("Authenticated with github: " + user.username);
             confirmOrgMembership(user)
             .then(function(authResponse) {
@@ -43,9 +48,6 @@ module.exports = {
                   debug('Got login from ' + user.username);
                   res.redirect("/");
                });
-            }, function(err) {
-               debug("Error: " + err);
-               next(err);
             });
          })(req,res,next);
       });
@@ -85,7 +87,7 @@ if (config.github.requireTeam) {
       });
    };
 } else {
-   checkOrgMembershipRequirements = 
+   checkOrgMembershipRequirements =
     Promise.denodeify(github.orgs.getMember);
 }
 


### PR DESCRIPTION
We were passing both a success and error callback to `passport.authenticate`,
which doesn't match the way that that function handles errors.
`passport.authentiate` passes an error object as the first parameter to the
first callback which we now check before operating on the response from the
OAuth authentication.

Based on the passport source, the second callback was being clobbered when the
second argument was also a callback.