### PR TITLE
Redirect to original URL after OAuth success

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,6 +6,7 @@ module.exports = function(grunt) {
     // Task configuration.
     jshint: {
       options: {
+        esversion: 6,
         curly: true,
         eqeqeq: true,
         latedef: 'nofunc', // Allow function definitions after their use.

--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -46,7 +46,12 @@ module.exports = {
                debug("Authenticated with org: " + user.username);
                req.logIn(user, function(err) {
                   debug('Got login from ' + user.username);
-                  res.redirect("/");
+
+                  // Redirect user to original URL. Fallback to '/' if DNE.
+                  let redirectUrl = req.session.auth_redirect;
+                  delete req.session.auth_redirect;
+
+                  res.redirect(redirectUrl || '/');
                });
             });
          })(req,res,next);
@@ -55,6 +60,9 @@ module.exports = {
       // Ensure index is authenticated.
       app.get('/', function (req, res, next) {
          if (req.isAuthenticated()) { return next(); }
+
+         // Store original URL for post-auth redirect
+         req.session.auth_redirect = req.originalUrl;
          res.redirect('/auth/github');
       });
    }


### PR DESCRIPTION
Previously if you accessed pulldasher using a query param like `assigned` or
`milestone` and you were placed in an OAuth redirect, your query params would
be forgetten after returning from OAuth redirects.

This stores the original URL in the session so that when the user gets back
from an OAuth redirect, the app redirects them to their original URL and not
just `'/'`.

CC @sctice 