### PR TITLE
Fix deprecated express middleware uses

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,11 @@ app.use("/lib", express.static(__dirname + '/bower_components'));
 app.use(partials());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
-app.use(expressSession({secret: config.session.secret}));
+app.use(expressSession({
+   secret: config.session.secret,
+   resave: false,
+   saveUninitialized: false
+}));
 app.use(passport.initialize());
 app.use(passport.session());
 

--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -19,7 +19,7 @@ var HooksController = {
       var dbUpdated;
       var comment;
 
-      var secret = req.param('secret');
+      var secret = req.query.secret;
       if (secret !== config.github.hook_secret) {
          var m = 'Invalid Hook Secret: ' + secret;
          debug(m);


### PR DESCRIPTION
This adds more explicit values to `express-session` and removes the use of the
deprecated `req.param` method.

`req.param` is deprecated because it searches for a value from the
* route matching
* query params
* request body

There are individual functions to use for each of those, so it's recommended to
use those instead of the larger generic one. This was used for something that's
always a query param, so the usage is switched to `req.query`.