### PR TITLE
Remove repo name

### DIFF
--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -74,7 +74,6 @@ var HooksController = {
             promises.push(dbManager.insertSignatures(sigs));
 
             body.comment.number = body.issue.number;
-            body.comment.repo_name = body.repository.name;
             body.comment.repo = body.repository.full_name;
             body.comment.type = 'issue';
             comment = new Comment(body.comment);
@@ -96,7 +95,6 @@ var HooksController = {
             dbUpdated = dbManager.deleteReviewComment(body.comment.id);
          } else {
             body.comment.number = body.pull_request.number;
-            body.comment.repo_name = body.repository.name;
             body.comment.repo = body.repository.full_name;
             body.comment.type =   'review';
             comment = new Comment(body.comment);

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -173,7 +173,6 @@ module.exports = {
          // Array of Comment objects.
          comments = comments.map(function(commentData) {
             commentData.number = githubPull.number;
-            commentData.repo_name = githubPull.base.repo.name;
             commentData.repo = githubPull.base.repo.full_name;
             commentData.type = 'issue';
 
@@ -183,7 +182,6 @@ module.exports = {
          // Array of Comment objects.
          comments = comments.concat(reviewComments.map(function(commentData) {
             commentData.number = githubPull.number;
-            commentData.repo_name = githubPull.base.repo.name;
             commentData.repo = githubPull.base.repo.full_name;
             commentData.type = 'review';
 

--- a/migrations/0009-allow-null-repo-names.sql
+++ b/migrations/0009-allow-null-repo-names.sql
@@ -1,0 +1,6 @@
+ALTER TABLE comments MODIFY COLUMN repo_name varchar(255) NULL;
+ALTER TABLE pull_labels MODIFY COLUMN repo_name varchar(255);
+ALTER TABLE pulls MODIFY COLUMN repo_name varchar(255);
+
+ALTER TABLE pulls DROP KEY pulls_repo;
+ALTER TABLE pulls ADD KEY pulls_repo (repo);

--- a/migrations/0010-drop-repo-names.sql
+++ b/migrations/0010-drop-repo-names.sql
@@ -1,0 +1,3 @@
+ALTER TABLE comments DROP COLUMN repo_name;
+ALTER TABLE pull_labels DROP COLUMN repo_name;
+ALTER TABLE pulls DROP COLUMN repo_name;

--- a/models/comment.js
+++ b/models/comment.js
@@ -8,7 +8,6 @@ function Comment(data) {
    this.data = {
       number:        data.number,
       repo:          data.repo,
-      repo_name:     data.repo_name,
       user: {
          login: getLogin(data.user)
       },
@@ -26,7 +25,6 @@ Comment.getFromDB = function(data) {
    return new Comment({
       number:     data.number,
       repo:       data.repo,
-      repo_name:  data.repo_name,
       user: {
          login: data.user
       },

--- a/models/db_comment.js
+++ b/models/db_comment.js
@@ -11,7 +11,6 @@ function DBComment(comment) {
    var commentData = comment.data;
    this.data = {
       number:     commentData.number,
-      repo_name:  commentData.repo_name,
       repo:       commentData.repo,
       user:       getLogin(commentData.user),
       date:       utils.toUnixTime(commentData.created_at),

--- a/models/db_label.js
+++ b/models/db_label.js
@@ -8,7 +8,6 @@ function DBLabel(label) {
    this.data = {
       number: labelData.number,
       title: labelData.title,
-      repo_name: labelData.repo_name,
       repo: labelData.repo,
       user: labelData.user,
       date: utils.toUnixTime(labelData.created_at)

--- a/models/db_pull.js
+++ b/models/db_pull.js
@@ -22,7 +22,6 @@ function DBPull(pull) {
       head_branch: pullData.head.ref,
       head_sha: pullData.head.sha,
       repo_owner: pullData.head.repo.owner.login,
-      repo_name: pullData.head.repo.name,
       base_branch: pullData.base.ref,
       owner: getLogin(pullData.user),
       cr_req: pullData.cr_req,

--- a/models/label.js
+++ b/models/label.js
@@ -8,7 +8,6 @@ function Label(data, pullNumber, repoName, repoFullName, user, created_at) {
       title: data.name,
       number: pullNumber,
       repo: repoFullName,
-      repo_name: repoName,
       user: user,
       created_at: utils.fromDateString(created_at)
    };
@@ -23,7 +22,6 @@ Label.getFromDB = function getFromDB(data) {
    return new Label(
       { name: data.title },
       data.number,
-      data.repo_name,
       data.repo,
       data.user,
       utils.fromUnixTime(data.date)

--- a/models/pull.js
+++ b/models/pull.js
@@ -221,8 +221,7 @@ Pull.getFromDB = function(data, signatures, comments, commitStatus, labels) {
          repo: {
             owner: {
                login: data.repo_owner
-            },
-            name: data.repo_name,
+            }
          }
       },
       base: {

--- a/public/js/Pull.js
+++ b/public/js/Pull.js
@@ -5,7 +5,7 @@ define(['underscore', 'appearanceUtils', 'socket'], function(_, utils, socket) {
 
    _.extend(constructor.prototype, {
       url: function() {
-         return 'https://github.com/' + this.head.repo.owner.login + '/' + this.head.repo.name + '/pull/' + this.number;
+         return 'https://github.com/' + this.repo + '/pull/' + this.number;
       },
 
       update: function(data) {

--- a/schema.sql
+++ b/schema.sql
@@ -32,7 +32,7 @@ CREATE TABLE `comments` (
   `comment_type` enum('issue','review') NOT NULL DEFAULT 'issue',
   `comment_id` int(10) unsigned NOT NULL,
   `number` int(10) unsigned NOT NULL,
-  `repo_name` varchar(255) NOT NULL,
+  `repo_name` varchar(255) DEFAULT NULL,
   `user` varchar(255) NOT NULL,
   `date` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`repo`,`comment_type`,`comment_id`),
@@ -88,7 +88,7 @@ CREATE TABLE `pull_labels` (
   `repo` varchar(255) DEFAULT NULL,
   `number` int(10) unsigned NOT NULL,
   `title` varchar(32) NOT NULL,
-  `repo_name` varchar(255) NOT NULL,
+  `repo_name` varchar(255) DEFAULT NULL,
   `user` varchar(255) DEFAULT NULL,
   `date` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`repo`,`number`,`title`),
@@ -131,7 +131,7 @@ CREATE TABLE `pulls` (
   `head_branch` varchar(255) NOT NULL,
   `head_sha` char(40) NOT NULL,
   `repo_owner` varchar(255) NOT NULL,
-  `repo_name` varchar(255) NOT NULL,
+  `repo_name` varchar(255) DEFAULT NULL,
   `base_branch` varchar(255) NOT NULL,
   `owner` varchar(255) NOT NULL,
   `cr_req` int(11) NOT NULL DEFAULT '2',
@@ -147,8 +147,8 @@ CREATE TABLE `pulls` (
   `difficulty` int(11) DEFAULT NULL,
   PRIMARY KEY (`repo`,`number`),
   KEY `pulls_state` (`state`),
-  KEY `pulls_repo` (`repo_owner`,`repo_name`),
-  KEY `pulls_user` (`owner`)
+  KEY `pulls_user` (`owner`),
+  KEY `pulls_repo` (`repo`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!50112 SET @disable_bulk_load = IF (@is_rocksdb_supported, 'SET SESSION rocksdb_bulk_load = @old_rocksdb_bulk_load', 'SET @dummy_rocksdb_bulk_load = 0') */;

--- a/schema.sql
+++ b/schema.sql
@@ -32,11 +32,10 @@ CREATE TABLE `comments` (
   `comment_type` enum('issue','review') NOT NULL DEFAULT 'issue',
   `comment_id` int(10) unsigned NOT NULL,
   `number` int(10) unsigned NOT NULL,
-  `repo_name` varchar(255) DEFAULT NULL,
   `user` varchar(255) NOT NULL,
   `date` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`repo`,`comment_type`,`comment_id`),
-  KEY `pull` (`repo_name`,`number`)
+  KEY `pull` (`number`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -88,7 +87,6 @@ CREATE TABLE `pull_labels` (
   `repo` varchar(255) DEFAULT NULL,
   `number` int(10) unsigned NOT NULL,
   `title` varchar(32) NOT NULL,
-  `repo_name` varchar(255) DEFAULT NULL,
   `user` varchar(255) DEFAULT NULL,
   `date` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`repo`,`number`,`title`),
@@ -131,7 +129,6 @@ CREATE TABLE `pulls` (
   `head_branch` varchar(255) NOT NULL,
   `head_sha` char(40) NOT NULL,
   `repo_owner` varchar(255) NOT NULL,
-  `repo_name` varchar(255) DEFAULT NULL,
   `base_branch` varchar(255) NOT NULL,
   `owner` varchar(255) NOT NULL,
   `cr_req` int(11) NOT NULL DEFAULT '2',

--- a/views/standard/spec/pageIndicators.js
+++ b/views/standard/spec/pageIndicators.js
@@ -102,8 +102,7 @@ define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils'], function($, _,
          // If we have frozen pulls, make the count a link.
          if (frozen.length) {
             // Pull the repo and org from the first frozen pull.
-            var repo = frozen[0].head.repo.name;
-            var org = frozen[0].head.repo.owner.login;
+            var repo = frozen[0].repo;
             var label = 'Cryogenic Storage';
             var link = $('<a target="_blank" href="https://www.github.com/' + org + '/' + repo + '/labels/' + label + '"></a>');
             node.wrapInner(link);

--- a/views/standard/spec/pageIndicators.js
+++ b/views/standard/spec/pageIndicators.js
@@ -104,7 +104,7 @@ define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils'], function($, _,
             // Pull the repo and org from the first frozen pull.
             var repo = frozen[0].repo;
             var label = 'Cryogenic Storage';
-            var link = $('<a target="_blank" href="https://www.github.com/' + org + '/' + repo + '/labels/' + label + '"></a>');
+            var link = $('<a target="_blank" href="https://www.github.com/' + repo + '/labels/' + label + '"></a>');
             node.wrapInner(link);
          }
       },


### PR DESCRIPTION
Now that repo is the new column that is being used in all of the tables, the old repo_name and repo_owner columns can be dropped for good.

QA: Run the migrations, then test all the normal features of pulldasher, signing off and having it update, moving pulls between columns, and test all the links to pulls and their build statuses

Closes: https://github.com/iFixit/pulldasher/issues/79