### PR TITLE
Search GitHub org for repos

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ var config = require('./config'),
     refresh = require('./lib/refresh'),
     pullManager = require('./lib/pull-manager'),
     dbManager = require('./lib/db-manager'),
+    gitManager = require('./git-manager'),
     pullQueue  = require('./lib/pull-queue'),
     mainController = require('./controllers/main'),
     hooksController = require('./controllers/githubHooks'),
@@ -55,7 +56,18 @@ authManager.setupRoutes(app);
 app.get('/',            mainController.index);
 app.post('/hooks/main', hooksController.main);
 
-config.repos.forEach(function(repo) {
+
+var repos = [];
+
+if (config.organization) {
+   repos = repos.concat(gitManager.getOrgRepos(config.organization));
+}
+
+if (config.repos) {
+   repos = repos.concat(config.repos);
+}
+
+repos.forEach(function(repo) {
    // Load open pulls from the DB so we don't start blank.
    dbManager.getOpenPulls(repo).then(function(pulls) {
       pullQueue.pause();

--- a/config.example.js
+++ b/config.example.js
@@ -47,6 +47,9 @@ module.exports = {
      "owner/name"
    ],
 
+   // Show pull requests from all repos belonging to this organization
+   organization: "owner",
+
    // The usual MySQL stuff. Like every other MySQL webapp, basically.
    // You will need to source the `schema.sql` file in the database to create
    // all the tables that Pulldasher expects.

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -39,6 +39,7 @@ api.getPullReviewComments  = denodeify(github.pullRequests.getComments);
 api.getCommit              = denodeify(github.repos.getCommits);
 api.getCommitStatus        = denodeify(github.statuses.get);
 var getNextPage            = denodeify(github.getNextPage.bind(github));
+var getOrgRepos            = denodeify(github.repos.getForOrg);
 
 module.exports = {
    github: github,
@@ -114,6 +115,17 @@ module.exports = {
       .then(getAllPages)
       .then(filterOutPulls)
       .then(addRepo(searchParams));
+   },
+
+   /**
+    * Get all repos an organization owns
+    *
+    * Fetches a maximum of 100 repos for now.
+    */
+   getOrgRepos: function(org) {
+      return getOrgRepos({org})
+      .then(getAllPages)
+      .then(repos => repos.map(repo => repo.full_name));
    },
 
    /**


### PR DESCRIPTION
Rather than requiring each repo to be listed, automatically search for
all repos in a GitHub organization and watch them.

QA
---
These changes are currently completely untested.