### PR TITLE
Add external block icon

### DIFF
--- a/views/standard/less/components/pull.less
+++ b/views/standard/less/components/pull.less
@@ -191,6 +191,12 @@
          color: @tag-qaing-mine;
       }
    }
+
+   &.externally-blocked {
+      color: @tag-externally-blocked;
+      border-color: @tag-externally-blocked-border;
+      background: @tag-externally-blocked-background;
+   }
 }
 
 .status {

--- a/views/standard/less/themes/colors/day_colors.less
+++ b/views/standard/less/themes/colors/day_colors.less
@@ -110,6 +110,10 @@
 @tag-qaing-border: @tag-default-border;
 @tag-qaing-background: @tag-default-background;
 
+@tag-externally-blocked: @red;
+@tag-externally-blocked-border: @tag-default-border;
+@tag-externally-blocked-background: @tag-default-background;
+
 @user-icon: @blue;
 
 // CR and QA boxes

--- a/views/standard/less/themes/colors/night_colors.less
+++ b/views/standard/less/themes/colors/night_colors.less
@@ -116,6 +116,10 @@
 @tag-qaing-border: @tag-default-border;
 @tag-qaing-background: @tag-default-background;
 
+@tag-externally-blocked: @red;
+@tag-externally-blocked-border: @tag-default-border;
+@tag-externally-blocked-background: @tag-default-background;
+
 @user-icon: @blue;
 
 // CR and QA boxes

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -293,6 +293,13 @@ define(['jquery', 'appearanceUtils', 'underscore'], function($, utils, _) {
                    label.created_at, label.user);
                   node.append(icon);
                }
+               if ((label = pull.getLabel('external_block'))) {
+                  var icon = $('<i>').addClass('fa fa-eye-slash externally-blocked');
+
+                  utils.addActionTooltip(icon, 'Externally Blocked',
+                   label.created_at, label.user);
+                  node.append(icon);
+               }
             }
          }
       }


### PR DESCRIPTION
In https://github.com/iFixit/pulldasher/issues/87 we decided to add an `external_block` label to pulls that require input or QA from someone outside of our department. When you add the `external_block` label to a github issue a red eye with a slash with show up next to the pull in the QAing column.
![image](https://user-images.githubusercontent.com/10774982/29744348-3254b494-8a58-11e7-96ed-247420881e4b.png)


### QA
Come talk to me and we can QA this together. Or I can help get you set up with docker and explain how to QA it on your own. 

Closes #99