### PR TITLE
db-manager: simplify signatures query

### DIFF
--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -347,10 +347,9 @@ var dbManager = module.exports = {
 
    getAllSignatures: function(repo, number) {
       var q_select = '\
-         SELECT * FROM comments \
-         JOIN pull_signatures USING (comment_id, number) \
-         WHERE number = ? AND comments.repo = ? \
-         ORDER BY pull_signatures.date desc;';
+         SELECT * FROM pull_signatures \
+         WHERE number = ? AND repo = ? \
+         ORDER BY date desc;';
 
       return db.query(q_select, [number, repo]).then(function(rows) {
          return rows.map(function(row) {


### PR DESCRIPTION
This query was really slow cause the join was on a column
that wasn't indexed. After examining the usage of this func,
we only need the columns from pull_signatures anyway.

It went from 1400ms to < 10ms.

Closes #104