### PR TITLE
Don't automatically refresh open pulls on start

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,11 +63,7 @@ config.repos.forEach(function(repo) {
          pullManager.updatePull(pull);
       });
       pullQueue.resume();
-   })
-   // Get the most recent version of each pull from the API
-   .then(function () {
-      return refresh.openPulls();
-   }).done();
+   });
 });
 
 /*

--- a/app.js
+++ b/app.js
@@ -63,7 +63,7 @@ config.repos.forEach(function(repo) {
          pullManager.updatePull(pull);
       });
       pullQueue.resume();
-   });
+   }).done();
 });
 
 /*


### PR DESCRIPTION
This was causing the pulldasher app to go over its rate limits pretty
frequently. It was extremely problematic since it would crash on hitting
the rate limit, and immediately crash into the rate limit again.

When there are a very large number of repositories and thus many items
pulldasher needs to lookup, it approaches the rate limit very quickly.