### PR TITLE
Use new org/repo string for Cryogenic pull links

### DIFF
--- a/views/standard/spec/pageIndicators.js
+++ b/views/standard/spec/pageIndicators.js
@@ -101,10 +101,10 @@ define(['jquery', 'underscore', 'spec/utils', 'appearanceUtils'], function($, _,
 
          // If we have frozen pulls, make the count a link.
          if (frozen.length) {
-            // Pull the repo and org from the first frozen pull.
+            // Pull the org/repo string from the first frozen pull.
             var repo = frozen[0].repo;
             var label = 'Cryogenic Storage';
-            var link = $('<a target="_blank" href="https://www.github.com/' + org + '/' + repo + '/labels/' + label + '"></a>');
+            var link = $('<a target="_blank" href="https://www.github.com/' + repo + '/labels/' + label + '"></a>');
             node.wrapInner(link);
          }
       },


### PR DESCRIPTION
We were using a leftover `org` variable to construct a string to the
github page where all pulls with the cryo label exist. The new way a
repo is represented is a string like "org/repo", so instead of relying
on an org and a repo, we can just include that string as the first two
parts of the github URL path.