### PR TITLE
Labels: Remove extra repo name parameter

### DIFF
--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -177,7 +177,6 @@ function handleLabelEvents(body) {
          return dbManager.insertLabel(new Label(
             body.label,
             object.number,
-            body.repository.name,
             body.repository.full_name,
             getLogin(body.sender),
             object.updated_at
@@ -188,7 +187,6 @@ function handleLabelEvents(body) {
          return dbManager.deleteLabel(new Label(
             body.label,
             object.number,
-            body.repository.name,
             body.repository.full_name
          ));
    }

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -307,7 +307,6 @@ function getLabelsFromEvents(events, ghIssue) {
          return new Label(
             {name: label.name},
             ghIssue.number,
-            "", // TODO: Remove this when repo_name is removed.
             ghIssue.repo,
             eventLabel && eventLabel.user,
             eventLabel && eventLabel.created_at
@@ -320,7 +319,6 @@ function getLabelsFromEvents(events, ghIssue) {
       return new Label(
          {name: label.name},
          ghIssue.number,
-         "", // TODO: Remove this when repo_name is removed.
          ghIssue.repo,
          label.user,
          label.created_at

--- a/models/label.js
+++ b/models/label.js
@@ -3,7 +3,7 @@ var utils  = require('../lib/utils');
 /**
  * Build a Label object.
  */
-function Label(data, pullNumber, repoName, repoFullName, user, created_at) {
+function Label(data, pullNumber, repoFullName, user, created_at) {
    this.data = {
       title: data.name,
       number: pullNumber,


### PR DESCRIPTION
The `Label` constructor and its callsites were using different numbers of
parameters. For the few that were using too little, the fields were
being incorrectly set to the wrong label fields, i.e. the repo field
would be set to the user value.

This removes the extra constructor parameter and removes arguments left
over from before the `repo_name` column was removed.

qa_req 0

![screenshot from 2017-10-09 22-13-30](https://user-images.githubusercontent.com/2539016/31370297-1d194bbc-ad3f-11e7-905d-07d5d3d83720.png)

This also works for label add and delete webhooks.

Closes #117 