### PR TITLE
Add rule for external_block sorting

### DIFF
--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -278,6 +278,12 @@ define(['jquery', 'appearanceUtils', 'underscore'], function($, utils, _) {
                // current CRs to become complete, push it up.
                score -= 1;
             }
+            
+            var extBlockLabel = pull.getLabel('external_block');
+            
+            if (extBlockLabel) {
+               score += 1000;
+            }
 
             return score;
          },

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -282,7 +282,7 @@ define(['jquery', 'appearanceUtils', 'underscore'], function($, utils, _) {
             var extBlockLabel = pull.getLabel('external_block');
             
             if (extBlockLabel) {
-               score += 1000;
+               score += 2000;
             }
 
             return score;


### PR DESCRIPTION
If a pull is externally blocked, there's no need to look at it. Let's move it to the bottom of the column and out of sight.

QA Instructions:
These changes are live on our pulldasher. As long as external_block pulls are consistently at the bottom of the queue for a few days or so we can sign off on this.

Closes #119 