### PR TITLE
Start node inspector when DEBUG is set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,15 @@ services:
    web:
       build: .
       entrypoint: '/opt/pulldasher/entrypoint.sh'
+      environment:
+         DEBUG: pulldasher*         # Enables all debug prints and opens 127.0.0.1:9229 for remote debugging
       ports:
          - 8080:8080                # Map the container's port 8080 to the host's 8080
                                     # NOTE: The host port will need to match
                                     # the callback URL specified in the GitHub
                                     # application setting.
+
+         - 9229:9229                # Map debugging port to localhost
       volumes:
          - .:/opt/pulldasher        # Mount the current directory to /opt/pulldasher
    db:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,4 +11,8 @@ done
 echo "Setup done, starting pulldasher..."
 
 # Start pulldasher
-bin/pulldasher
+if [ -n "$DEBUG" ]; then
+   node --inspect="0.0.0.0:9229" bin/pulldasher
+else
+   node bin/pulldasher
+fi


### PR DESCRIPTION
When the DEBUG environment variable is set, make sure to start
Pulldasher with the `--inspect` flag. This lets you connect a debugger
remotely (DevTools for Node, node-inspector).

cr_req 1
qa_req 0 I started up a debug instance of pulldasher with Chrome DevTools open and successfully attached.