### PR TITLE
Shows pulls from repos without CI in QA column

### DIFF
--- a/public/js/Pull.js
+++ b/public/js/Pull.js
@@ -72,8 +72,15 @@ _.extend(Pull.prototype, {
     * on which both the "deploy_blocked" and "Ready" columns are based.
     */
    ready: function() {
-      return !this.dev_blocked() && this.qa_done() &&
-       this.cr_done() && this.build_succeeded();
+      return this.noCICheckReady() && this.build_succeeded();
+   },
+
+   buildUnavailableReady: function() {
+      return this.noCICheckReady() && this.build_unavailable();
+   },
+
+   noCICheckReady: function() {
+      return !this.dev_blocked() && this.qa_done() && this.cr_done();
    },
 
    author: function() {
@@ -115,6 +122,10 @@ _.extend(Pull.prototype, {
 
    build_succeeded: function() {
       return this.build_status() === 'success';
+   },
+
+   build_unavailable: function() {
+      return this.status.commit_status === null;
    },
 
    refresh: function() {

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -230,7 +230,7 @@ export default [
       id: "qaPulls",
       selector: function(pull) {
          return !pull.qa_done() && !pull.dev_blocked() &&
-          pull.build_succeeded();
+          (pull.build_succeeded() || !pull.status.commit_status);
       },
       sort: function(pull) {
          // The higher score is, the lower the pull will be sorted.

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -54,7 +54,8 @@ export default [
       // `false` otherwise. This property may also be an array of functions,
       // in which case the selectors are chained.
       selector: function(pull) {
-         return !pull.dev_blocked() && !pull.build_succeeded();
+         return !pull.dev_blocked() && !pull.build_succeeded() &&
+          !pull.build_unavailable();
       },
       // This describes the sort order for the pull. It returns a numeric
       // score for each pull. Pulls with a low score are sorted to the bottom
@@ -102,7 +103,8 @@ export default [
       title: "Deploy Blocked Pulls",
       id: "deployBlockPulls",
       selector: function(pull) {
-         return pull.ready() && pull.deploy_blocked();
+         return (pull.ready() && pull.deploy_blocked()) ||
+          pull.buildUnavailableReady();
       },
       triggers: {
          onCreate: function(blob) {
@@ -230,7 +232,7 @@ export default [
       id: "qaPulls",
       selector: function(pull) {
          return !pull.qa_done() && !pull.dev_blocked() &&
-          (pull.build_succeeded() || !pull.status.commit_status);
+          (pull.build_succeeded() || pull.build_unavailable());
       },
       sort: function(pull) {
          // The higher score is, the lower the pull will be sorted.

--- a/views/standard/spec/columns.js
+++ b/views/standard/spec/columns.js
@@ -126,6 +126,12 @@ export default [
                current_block.created_at, current_block.user.login);
 
                node.append(link);
+            } else if (pull.buildUnavailableReady()) {
+               const icon = $('<i>').addClass('fa fa-exclamation deploy-blocked');
+
+               utils.addTooltip(icon, 'No CI - Deploy Carefully');
+
+               node.append(icon);
             }
          }
       },


### PR DESCRIPTION
This pull changes QA column behavior to include any pulls that don't have CI set up in their repo. Previous behavior would block these pulls from showing up outside of CI-Blocked and CR columns.

| Current | Updated |
|---------|---------|
| ![image](https://user-images.githubusercontent.com/1361631/36055315-85799ff0-0db0-11e8-974c-874147d23576.png) | ![image](https://user-images.githubusercontent.com/1361631/36055310-7c611a74-0db0-11e8-8765-6c7aaacbf4f2.png) |

CR
--
- `pull.status.commit_status` is an object that is falsey (`null`) if there's no CI set up, and truthy if there is CI but it's failing or not ran yet.

QA
--
Talk to me about how to set up a test instance of Pulldasher.

Closes #130 