### PR TITLE
Upgrade node-github to @octokit/rest

### DIFF
--- a/bin/refresh-open-pulls
+++ b/bin/refresh-open-pulls
@@ -5,6 +5,6 @@ var refresh = require('../lib/refresh');
 var db = require('../lib/db');
 
 refresh.openPulls()
-.done(function() {
+.then(function() {
    db.end();
 });

--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -1,7 +1,6 @@
 var config = require('../config'),
     debug = require('./debug')('pulldasher:authentication'),
     github = require('./git-manager').github,
-    Promise = require('bluebird'),
     passport = require('passport'),
     _ = require('underscore'),
     GitHubStrategy = require('passport-github').Strategy;
@@ -74,18 +73,15 @@ module.exports = {
 };
 
 
-var checkOrgMembershipRequirements;
+let checkOrgMembershipRequirements;
 
 if (config.github.requireTeam) {
    // All this logic is needed to get the team id from a team name
-   var getTeams = Promise.promisify(github.orgs.getTeams);
-   var checkTeamMembership = Promise.promisify(github.orgs.getTeamMember);
-
-   var getTeamId = getTeams({org: config.github.requireOrg})
+   const getTeamId = github.orgs.getTeams({org: config.github.requireOrg})
    .then(function(teams) {
-      var team = _.findWhere(teams, {name: config.github.requireTeam});
+      const team = _.findWhere(teams, {name: config.github.requireTeam});
       if (!team) {
-         var m = "Team " + (config.github.requireTeam) + " not found in Organization: " + config.github.requireOrg;
+         const m = "Team " + (config.github.requireTeam) + " not found in Organization: " + config.github.requireOrg;
          debug(m);
          console.error(m);
          process.exit(1);
@@ -96,17 +92,16 @@ if (config.github.requireTeam) {
    checkOrgMembershipRequirements = function(options) {
       return getTeamId.then(function(teamId) {
          options.id = teamId;
-         return checkTeamMembership(options);
+         return github.orgs.getTeamMembership(options);
       });
    };
 } else {
-   checkOrgMembershipRequirements =
-    Promise.promisify(github.orgs.getMember);
+   checkOrgMembershipRequirements = github.orgs.checkMembership;
 }
 
 function confirmOrgMembership(user) {
    return checkOrgMembershipRequirements({
       org: config.github.requireOrg,
-      user: user.username
+      username: user.username
    });
 }

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -113,8 +113,8 @@ var dbManager = module.exports = {
          // `pullNumber` will be null if we are updating the build status of a commit
          // which is no longer a pull's head commit.
          if (pullNumber === null) {
-            debug('updateCommitStatus: commit no longer HEAD of Pull #%s in repo %s',
-                pullNumber, updatedStatus.data.repo);
+            debug('updateCommitStatus: commit %s is not the HEAD of any pull, none to refresh in repo %s',
+               updatedStatus.data.sha, updatedStatus.data.repo);
             return;
          }
 

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -104,26 +104,23 @@ var dbManager = module.exports = {
     */
    updateCommitStatus: function(updatedStatus) {
       debug('Calling `updateCommitStatus` for commit %s in repo %s',
-       updatedStatus.data.commit, updatedStatus.data.repo);
+       updatedStatus.data.sha, updatedStatus.data.repo);
       var dbStatus = new DBStatus(updatedStatus);
-      var number = this.getPullNumberFromSha(dbStatus.data.repo, dbStatus.data.commit);
 
       return dbStatus.save().
-      then(function() {
-         return number;
-      }).
-      then(function(n) {
-         // `n` will be null if we are updating the build status of a commit
+      then(() => this.getPullNumberFromSha(updatedStatus.data.repo, updatedStatus.data.sha)).
+      then(function(pullNumber) {
+         // `pullNumber` will be null if we are updating the build status of a commit
          // which is no longer a pull's head commit.
-         if (n === null) {
+         if (pullNumber === null) {
             debug('updateCommitStatus: commit no longer HEAD of Pull #%s in repo %s',
-                number, updatedStatus.data.repo);
+                pullNumber, updatedStatus.data.repo);
             return;
          }
 
-         queue.markPullAsDirty(dbStatus.data.repo, n);
+         queue.markPullAsDirty(dbStatus.data.repo, pullNumber);
          debug('updateCommitStatus: updated status of Pull #%s in repo %s',
-             number, dbStatus.data.repo);
+             pullNumber, dbStatus.data.repo);
       });
    },
 
@@ -153,7 +150,7 @@ var dbManager = module.exports = {
     */
    insertSignature: function(signature) {
       debug('Calling insertSignature for pull #%s in repo %s',
-         signature.data.number, signature.repo);
+         signature.data.number, signature.data.repo);
       var dbSignature = new DBSignature(signature);
       var repo = dbSignature.data.repo;
       var number = dbSignature.data.number;

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -1,4 +1,4 @@
-var GithubApi = require('github'),
+var GithubApi = require('@octokit/rest'),
     config = require('../config'),
     Promise = require('bluebird'),
     _ = require('underscore'),
@@ -22,24 +22,6 @@ github.authenticate({
    token: config.github.token
 });
 
-function denodeify(func) {
-   return rateLimit(Promise.promisify(func));
-}
-
-var api = {};
-var getPull                = denodeify(github.pullRequests.get);
-var getAllPulls            = denodeify(github.pullRequests.getAll);
-var getIssue               = denodeify(github.issues.getRepoIssue);
-var getAllIssues           = denodeify(github.issues.repoIssues);
-api.getIssueEvents         = denodeify(github.issues.getEvents);
-// "issue" comments are the comments on the pull (issue) itself.
-api.getIssueComments       = denodeify(github.issues.getComments);
-// "review" comments are the comments on the diff of the pull
-api.getPullReviewComments  = denodeify(github.pullRequests.getComments);
-api.getCommit              = denodeify(github.repos.getCommits);
-api.getCommitStatus        = denodeify(github.statuses.get);
-var getNextPage            = denodeify(github.getNextPage.bind(github));
-
 module.exports = {
    github: github,
 
@@ -49,9 +31,8 @@ module.exports = {
     */
    getPull: function(repo, number) {
       debug("Getting pull %s", number);
-      return getPull(params({
-         number:     number
-      }, repo));
+      return github.pullRequests.get(params({ number }, repo))
+                                .then(res => res.data);
    },
 
    /**
@@ -61,7 +42,7 @@ module.exports = {
     */
    getOpenPulls: function(repo) {
       debug("Getting open pulls in repo %s", repo);
-      return getAllPulls(params({}, repo)).then(getAllPages);
+      return github.pullRequests.getAll(params({}, repo)).then(paginate);
    },
 
    /**
@@ -71,9 +52,8 @@ module.exports = {
     */
    getAllPulls: function(repo) {
       debug("Getting all pulls in repo %s", repo);
-      return getAllPulls(params({
-         state: 'all'
-      }, repo)).then(getAllPages);
+      return github.pullRequests.getAll(params({ state: 'all' }, repo))
+                                .then(paginate);
    },
 
    /**
@@ -82,10 +62,11 @@ module.exports = {
     * Returns a promise which resolves to a github issue
     */
    getIssue: function(repo, number) {
-      var searchParams = params({number: number}, repo);
+      const searchParams = params({ number }, repo);
       debug("Getting issue %s in repo %s", number, repo);
-      return getIssue(searchParams)
-      .then(addRepo(searchParams));
+      return github.issues.get(searchParams)
+                          .then(res => res.data)
+                          .then(addRepo(searchParams));
    },
 
    /**
@@ -94,10 +75,10 @@ module.exports = {
     * Returns a promise which resolves to an array of all open issues
     */
    getOpenIssues: function(repo) {
-      var searchParams = params({}, repo);
+      const searchParams = params({}, repo);
       debug("Getting open issues");
-      return getAllIssues(searchParams)
-      .then(getAllPages)
+      return github.issues.getAll(searchParams)
+      .then(paginate)
       .then(filterOutPulls)
       .then(addRepo(searchParams));
    },
@@ -108,10 +89,10 @@ module.exports = {
     * Returns a promise which resolves to an array of all issues
     */
    getAllIssues: function(repo) {
-      var searchParams = params({state: 'all'}, repo);
+      const searchParams = params({state: 'all'}, repo);
       debug("Getting all issues");
-      return getAllIssues(searchParams)
-      .then(getAllPages)
+      return github.issues.getAll(searchParams)
+      .then(paginate)
       .then(filterOutPulls)
       .then(addRepo(searchParams));
    },
@@ -190,7 +171,7 @@ module.exports = {
          }));
 
          // Status object.
-         var status = null;
+         let status = null;
          if (commitStatus) {
             status = new Status({
                repo:          repo,
@@ -202,9 +183,9 @@ module.exports = {
          }
 
          // Array of Label objects.
-         var labels = getLabelsFromEvents(events, ghIssue);
+         const labels = getLabelsFromEvents(events, ghIssue);
 
-         var pull = Pull.fromGithubApi(githubPull, signatures, comments, status, labels);
+         const pull = Pull.fromGithubApi(githubPull, signatures, comments, status, labels);
          return pull.syncToIssue();
       });
    },
@@ -228,26 +209,16 @@ module.exports = {
    },
 };
 
-/**
- * Traverses github's pagination to retrieve *all* the records.
- * Takes in the first page of results and returns a promise for *all* the
- * results.
- */
-function getAllPages(currentPage, allResults) {
-   debug("Got %s results", currentPage.length);
-   return new Promise(function (resolve, reject) {
-      allResults = allResults || [];
-      allResults.push(currentPage);
+async function paginate(res) {
+   let response = res;
+   let all = res.data;
 
-      if (!github.hasNextPage(currentPage)) {
-         debug("No more results");
-         return resolve(_.flatten(allResults));
-      }
+   while (github.hasNextPage(response)) {
+      response = await github.getNextPage(response);
+      all = all.concat(response.data);
+   }
 
-      resolve(getNextPage(currentPage).then(function (nextPage) {
-         return getAllPages(nextPage, allResults);
-      }));
-   });
+   return all;
 }
 
 /**
@@ -329,15 +300,13 @@ function getLabelsFromEvents(events, ghIssue) {
 /**
  * Return the default api params merged with the overrides
  */
-function params(apiParams, repo) {
-   var repoArray = parseRepo(repo);
-   var owner = repoArray[0];
-   var repoName = repoArray[1];
+function params(apiParams, fullRepoName) {
+   const [owner, repo] = parseRepo(fullRepoName);
 
    return _.extend({
-      user:       owner,
-      repo:       repoName,
-      per_page:   100,
+      owner,
+      repo,
+      per_page:   100
    }, apiParams);
 }
 
@@ -348,9 +317,9 @@ function params(apiParams, repo) {
  * we asked about, so we have to inject them to normalize the structure of the
  * object.
  */
-function addRepo(params) {
+function addRepo({owner, repo}) {
    function addRepositoryField(ghIssue) {
-      ghIssue.repo = params.user + "/" + params.repo;
+      ghIssue.repo = owner + "/" + repo;
    }
    return function(results) {
       if (Array.isArray(results)) {
@@ -373,56 +342,34 @@ function parseRepo(repo) {
 /**
  * Return a promise for all issue events for the given issue / pull
  */
-function getIssueEvents(repo, issueNumber) {
-   debug("Getting events for issue #%s", issueNumber);
-   return api.getIssueEvents(params({
-      number: issueNumber
-   }, repo)).then(getAllPages);
+function getIssueEvents(repo, number) {
+   debug("Getting events for issue #%s", number);
+   return github.issues.getEvents(params({ number }, repo))
+                       .then(paginate);
 }
 
-function getIssueComments(repo, issueNumber) {
-   debug("Getting comments for issue #%s", issueNumber);
-   return api.getIssueComments(params({
-      number: issueNumber
-   }, repo)).then(getAllPages);
+function getIssueComments(repo, number) {
+   debug("Getting comments for issue #%s", number);
+   return github.issues.getComments(params({ number }, repo))
+                       .then(paginate);
 }
 
-function getPullReviewComments(repo, pullNumber) {
-   debug("Getting pull review comments for pull #%s", pullNumber);
-   return api.getPullReviewComments(params({
-      number: pullNumber
-   }, repo)).then(getAllPages);
+function getPullReviewComments(repo, number) {
+   debug("Getting pull review comments for pull #%s", number);
+   return github.pullRequests.getComments(params({ number }, repo))
+                .then(paginate);
 }
 
 function getCommit(repo, sha) {
-   return new Promise(function (resolve, reject){
-      debug("Getting commit %s", sha);
-      api.getCommit(params({
-         sha: sha,
-         per_page: 1
-      }, repo)).then(function(commits) {
-         if (commits.length === 1) {
-            resolve(commits[0]);
-         } else {
-            return reject();
-         }
-      });
-   });
+   return github.repos.getCommit(params({ sha }, repo))
+                      .then(res => res.data);
 }
 
-function getCommitStatus(repo, sha) {
-   return new Promise(function(resolve, reject) {
-      debug("Getting commit status for %s", sha);
-      api.getCommitStatus(params({
-         sha: sha
-      }, repo)).then(function(status) {
-         if (status.length) {
-            resolve(status[0]);
-         } else {
-            resolve(null);
-         }
-      });
-   });
+function getCommitStatus(repo, ref) {
+   debug("Getting commit status for %s", ref);
+   return github.repos.getStatuses(params({ ref }, repo))
+                      .then(res => res.data)
+                      .then(statuses => statuses.length ? statuses[0] : null);
 }
 
 /**
@@ -430,9 +377,8 @@ function getCommitStatus(repo, sha) {
  */
 function filterOutPulls(issues) {
    debug("Filtering out pulls from list of %s issues", issues.length);
-   issues = _.filter(issues, function(issue) {
-      return !issue.pull_request || !issue.pull_request.url;
-   });
+   issues = _.filter(issues,
+                     issue => !issue.pull_request || !issue.pull_request.url);
    debug("Filtered down to %s issues", issues.length);
    return issues;
 }

--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -12,8 +12,7 @@ var chokePoint = 2000;
 // github's rate-limit headers and delays firing of requests to attempt to
 // stay under the rate limit.
 module.exports = function rateLimit(promiseFunc) {
-   return function () {
-      var args = arguments;
+   return function(...args) {
       return throttleRequest().then(function() {
          return promiseFunc.apply(null, args);
       }).then(captureRateLimitInfo);

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -27,7 +27,7 @@ module.exports = {
 
    openIssues: function refreshOpenIssues() {
       debug("refresh all open issues");
-      return utils.forEachRepo(gitManager.getOpenIssues, gitManager.params())
+      return utils.forEachRepo(gitManager.getOpenIssues)
       .then(pushAllOnQueue(issueQueue));
    },
 
@@ -55,7 +55,7 @@ module.exports = {
 
 /**
  * Returns a function that will:
- *    push its first argument to the sppecified Queue
+ *    push its first argument to the specified Queue
  *    and return a promise that is fulfilled when the item is fully processed.
  */
 function pushOnQueue(queue) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,21 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@octokit/rest": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.4.1.tgz",
+      "integrity": "sha512-Jn185ySmzBPOQA86rz+DrV4PQbj0sM5H+vGD2LJwPPhJV+Tt2a6uKQLkGH1GC7DYTRzrAexCQOvQP2HG6P1t8Q==",
+      "requires": {
+        "before-after-hook": "^1.1.0",
+        "btoa-lite": "^1.0.0",
+        "debug": "^3.1.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.0",
+        "lodash": "^4.17.4",
+        "node-fetch": "^2.1.1",
+        "url-template": "^2.0.8"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -304,6 +319,14 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
+    "agent-base": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
@@ -373,7 +396,50 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "delegates": "^1.0.0"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "dev": true,
+          "optional": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "argparse": {
@@ -1537,6 +1603,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+    },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
@@ -1772,6 +1843,11 @@
         "caniuse-lite": "^1.0.30000835",
         "electron-to-chromium": "^1.3.45"
       }
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer": {
       "version": "4.9.1",
@@ -3117,6 +3193,19 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -4421,8 +4510,33 @@
         "has-unicode": "^2.0.0",
         "object-assign": "^4.1.0",
         "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
       }
     },
     "get-caller-file": {
@@ -4541,10 +4655,6 @@
           }
         }
       }
-    },
-    "github": {
-      "version": "github:iFixit/node-github#0373d45dbbd6c2548b6ed9a0092e2a029e26a3e3",
-      "from": "github:iFixit/node-github#0373d45dbbd6c2548b6ed9a0092e2a029e26a3e3"
     },
     "github-username": {
       "version": "4.1.0",
@@ -5099,6 +5209,15 @@
         "statuses": ">= 1.3.1 < 2"
       }
     },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      }
+    },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
@@ -5116,6 +5235,15 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      }
     },
     "husky": {
       "version": "0.14.3",
@@ -7111,8 +7239,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -7643,7 +7770,16 @@
       "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.1"
+        "safe-buffer": "^5.1.1",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "dev": true
+        }
       }
     },
     "minizlib": {
@@ -7829,8 +7965,21 @@
       "dev": true,
       "optional": true,
       "requires": {
+        "debug": "^2.1.2",
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "negotiator": {
@@ -7855,6 +8004,11 @@
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
       "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
     },
     "node-libs-browser": {
       "version": "2.1.0",
@@ -7935,12 +8089,26 @@
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
         "needle": "^2.2.0",
+        "nopt": "^4.0.1",
         "npm-packlist": "^1.1.6",
         "npmlog": "^4.0.2",
         "rc": "^1.1.7",
         "rimraf": "^2.6.1",
         "semver": "^5.3.0",
         "tar": "^4"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        }
       }
     },
     "nomnom": {
@@ -8281,8 +8449,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "2.1.0",
@@ -8298,8 +8465,16 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-cancelable": {
       "version": "0.4.1",
@@ -8927,9 +9102,19 @@
       "dev": true,
       "optional": true,
       "requires": {
+        "deep-extend": "~0.4.0",
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "read-chunk": {
@@ -10356,7 +10541,17 @@
         "minipass": "^2.2.4",
         "minizlib": "^1.1.0",
         "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.1"
+        "safe-buffer": "^5.1.1",
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "temp": {
@@ -10635,11 +10830,50 @@
       "dev": true,
       "requires": {
         "cacache": "^10.0.4",
+        "find-cache-dir": "^1.0.0",
         "schema-utils": "^0.4.5",
         "serialize-javascript": "^1.4.0",
+        "source-map": "^0.6.1",
         "uglify-es": "^3.3.4",
         "webpack-sources": "^1.1.0",
         "worker-farm": "^1.5.2"
+      },
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+          "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "uid-safe": {
@@ -10836,6 +11070,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "url-to-options": {
       "version": "1.0.1",
@@ -11407,7 +11646,34 @@
       "resolved": false,
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "string-width": "^1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Simple pull request dashboard",
   "dependencies": {
+    "@octokit/rest": "^15.4.1",
     "bluebird": "^3.5.1",
     "body-parser": "^1.15.1",
     "bootstrap": "^3.3.7",
@@ -12,7 +13,6 @@
     "express-partials": "0.1.1",
     "express-session": "^1.15.6",
     "font-awesome": "^4.7.0",
-    "github": "github:iFixit/node-github#0373d45dbbd6c2548b6ed9a0092e2a029e26a3e3",
     "jquery": "^3.3.1",
     "js-cookie": "^2.2.0",
     "mysql": "^2.15.0",
@@ -45,9 +45,14 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.js": [ "eslint --fix", "git add" ]
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ]
   },
-  "eslintIgnore": [ "dist/bundle.js" ],
+  "eslintIgnore": [
+    "dist/bundle.js"
+  ],
   "main": "app.js",
   "repository": "git@github.com:ifixit/pulldasher.git",
   "author": "iFixit",


### PR DESCRIPTION
A long time ago we forked `node-github` in order to add some changes to it. We made a pull request on the upstream and then forgot to track the upstream once our forked changes made it back in.

Our fork is about 10+ major versions behind and at least one package rename, so this adds the necessary changes to track the current version of `@octokit/rest`.

In order to cause the least number of changes to Pulldasher, this only updates the underlying SDK calls underneath our own API in `git-manager.js`. Once this is stable for a little while we can look into removing our secondary API in favor of just using `@octokit/rest` directly.

Closes #75