### PR TITLE
Socket.io reconnection: stop refreshing the page

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,7 +77,7 @@ io.sockets.on('connection', function (socket) {
       socket.disconnect();
    }, unauthenticated_timeout);
 
-   socket.on('authenticate', function(token) {
+   socket.once('authenticate', function(token) {
       // They did respond. No need to drop their connection for not responding.
       clearTimeout(autoDisconnect);
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "start": "node app.js",
     "debug": "node inspect app.js",
     "postinstall": "webpack",
+    "build": "webpack",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/public/js/socket.js
+++ b/public/js/socket.js
@@ -13,5 +13,4 @@ socket.on('connect', function() {
    socket.emit('authenticate', token);
 });
 
-
 export default socket;

--- a/public/js/socket.js
+++ b/public/js/socket.js
@@ -13,4 +13,5 @@ socket.on('connect', function() {
    socket.emit('authenticate', token);
 });
 
+
 export default socket;


### PR DESCRIPTION
When you focus away from the tab for a while and then come back,
the page refreshes... Wat?

Turns out chrome kills the connection (or something). After coming back,
socket.io fires a 'connect' event. We then fire the 'auth' event
to the backend thinking this is the first time we connected.
The server can't make sense of our nonce and so returns a "fail,
please refresh" response.

Now, let's just only ever listen for one auth event per server-side
connection. So long as the server thinks they're still connected,
we don't care if the client thinks it's connecting for the first time
or reconnecting after being away.

Also, add a manual 'build' npm command. Previously, it only happened on
post-commit.