### PR TITLE
Authentication: Don't check org membership if not required

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     },
     "env": {
        "browser": true,
-       "node": true
+       "node": true,
+       "es6": true
     },
     "globals": {
        "App": true

--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -33,7 +33,7 @@ module.exports = {
       app.get('/auth/github', passport.authenticate('github'));
       app.get('/auth/github/callback', function(req, res, next) {
          passport.authenticate('github',
-         function(err, user, info) {
+         function(err, user) {
             if (err) {
                debug("Error: " + err);
                return next(err);
@@ -45,19 +45,30 @@ module.exports = {
             }
 
             debug("Authenticated with github: " + user.username);
-            confirmOrgMembership(user)
-            .then(function(authResponse) {
-               debug("Authenticated with org: " + user.username);
-               req.logIn(user, function(err) {
+            if (config.github.requireOrg) {
+               confirmOrgMembership(user).then(function() {
+                  debug("Authenticated with org: " + user.username);
+                  req.logIn(user, function() {
+                     debug('Got login from ' + user.username);
+
+                     // Redirect user to original URL. Fallback to '/' if DNE.
+                     const redirectUrl = req.session.auth_redirect;
+                     delete req.session.auth_redirect;
+
+                     res.redirect(redirectUrl || '/');
+                  });
+               });
+            } else {
+               req.logIn(user, function() {
                   debug('Got login from ' + user.username);
 
                   // Redirect user to original URL. Fallback to '/' if DNE.
-                  var redirectUrl = req.session.auth_redirect;
+                  const redirectUrl = req.session.auth_redirect;
                   delete req.session.auth_redirect;
 
                   res.redirect(redirectUrl || '/');
                });
-            });
+            }
          })(req,res,next);
       });
 
@@ -83,7 +94,7 @@ if (config.github.requireTeam) {
       if (!team) {
          const m = "Team " + (config.github.requireTeam) + " not found in Organization: " + config.github.requireOrg;
          debug(m);
-         console.error(m);
+         console.error(m); // eslint-disable-line no-console
          process.exit(1);
       }
       return team.id;


### PR DESCRIPTION
Hey everyone 👋, I was playing around with Pulldasher and ran into an issue with GitHub authentication where it would still check my org membership even if I left the requireOrg config variable as false.

This makes a change to not check a user's org membership if the
requireOrg field in config.js is falsy. Currently Pulldasher always
makes a call to GitHub to check the user's membership, when it shouldn't
if the user doesn't want to require an org.

I tested this with a requireOrg value of `iFixit`, in which I was not allowed to view my local pulldasher website, and with a value of `false`, in which I could view my local instance of pulldasher.