### PR TITLE
fix(authentication): deduplicate req.logIn function

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -45,9 +45,19 @@ module.exports = {
             }
 
             debug("Authenticated with github: " + user.username);
+            let afterMembershipValidation;
+
+            // If the config requires org membership, check that the
+            // user belongs to that org. Otherwise just log in.
             if (config.github.requireOrg) {
-               confirmOrgMembership(user).then(function() {
-                  debug("Authenticated with org: " + user.username);
+               afterMembershipValidation = confirmOrgMembership(user).then(
+                  () => debug('Authenticated with org: ' + user.username)
+               );
+            } else {
+               afterMembershipValidation = Promise.resolve();
+            }
+
+            afterMembershipValidation.then(() => {
                   req.logIn(user, function() {
                      debug('Got login from ' + user.username);
 
@@ -57,18 +67,9 @@ module.exports = {
 
                      res.redirect(redirectUrl || '/');
                   });
-               });
-            } else {
-               req.logIn(user, function() {
-                  debug('Got login from ' + user.username);
-
-                  // Redirect user to original URL. Fallback to '/' if DNE.
-                  const redirectUrl = req.session.auth_redirect;
-                  delete req.session.auth_redirect;
-
-                  res.redirect(redirectUrl || '/');
-               });
-            }
+            }).catch(err => {
+               next(err);
+            });
          })(req,res,next);
       });
 


### PR DESCRIPTION
This includes some CR changes that didn't make it into the previous PR haha.

This also adds a catch handler for the org membership check promise and
passes the error to `next` to be handled. Currently this goes to the
default error handler, but before this the unhandled promise rejection
would trigger a console warning but the response wouldn't end because the
middleware chain wouldn't continue.

Now the error message is printed out and the response is ended
successfully.

A few thoughtful CRs is enough. Worst case is login breaks and we revert.
qa_req 0