### PR TITLE
Multiple Commit Statuses: Implement MVP

### DIFF
--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -259,18 +259,18 @@ var dbManager = module.exports = {
       return db.query(q_select, [number, repo]).then(function(rows) {
          if (rows.length === 0) { return null; }
 
-         var dbPullData   = rows[0];
-         var signatures   = self.getAllSignatures(repo, number);
-         var comments     = self.getComments(repo, number);
-         var commitStatus = self.getCommitStatus(repo, dbPullData.head_sha);
-         var labels       = self.getLabels(repo, number);
+         var dbPullData     = rows[0];
+         var signatures     = self.getAllSignatures(repo, number);
+         var comments       = self.getComments(repo, number);
+         var commitStatus   = self.getCommitStatus(repo, dbPullData.head_sha);
+         var labels         = self.getLabels(repo, number);
 
          return Promise.all([signatures, comments, commitStatus, labels]).
          then(function(resolved) {
-            signatures   = resolved[0];
-            comments     = resolved[1];
-            commitStatus = resolved[2];
-            labels       = resolved[3];
+            signatures     = resolved[0];
+            comments       = resolved[1];
+            commitStatus   = resolved[2];
+            labels         = resolved[3];
 
             debug('getPull: retrieved Pull #%s in repo %s', number, repo);
             return Pull.getFromDB(dbPullData, signatures, comments,

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -103,8 +103,8 @@ var dbManager = module.exports = {
     * argument.
     */
    updateCommitStatus: function(updatedStatus) {
-      debug('Calling `updateCommitStatus` for commit %s in repo %s',
-       updatedStatus.data.sha, updatedStatus.data.repo);
+      debug('Calling `updateCommitStatus` for commit %s in repo %s and context %s',
+       updatedStatus.data.sha, updatedStatus.data.repo, updatedStatus.data.context);
       var dbStatus = new DBStatus(updatedStatus);
 
       return dbStatus.save().

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -38,10 +38,10 @@ var dbManager = module.exports = {
       return dbManager.updatePull(pull).then(function() {
          var updates = [];
 
-         if (pull.commitStatus) {
-            updates.push(
-               dbManager.updateCommitStatus(pull.commitStatus)
-            );
+         if (pull.commitStatuses) {
+            pull.commitStatuses.forEach(status => {
+               updates.push(dbManager.updateCommitStatus(status));
+            });
          }
 
          updates.push(
@@ -262,19 +262,19 @@ var dbManager = module.exports = {
          var dbPullData     = rows[0];
          var signatures     = self.getAllSignatures(repo, number);
          var comments       = self.getComments(repo, number);
-         var commitStatus   = self.getCommitStatus(repo, dbPullData.head_sha);
+         var commitStatuses = self.getCommitStatuses(repo, dbPullData.head_sha);
          var labels         = self.getLabels(repo, number);
 
-         return Promise.all([signatures, comments, commitStatus, labels]).
+         return Promise.all([signatures, comments, commitStatuses, labels]).
          then(function(resolved) {
             signatures     = resolved[0];
             comments       = resolved[1];
-            commitStatus   = resolved[2];
+            commitStatuses = resolved[2];
             labels         = resolved[3];
 
             debug('getPull: retrieved Pull #%s in repo %s', number, repo);
             return Pull.getFromDB(dbPullData, signatures, comments,
-             commitStatus, labels);
+             commitStatuses, labels);
          });
       });
    },
@@ -373,17 +373,13 @@ var dbManager = module.exports = {
    /**
     * Returns a promise which resolves to a Status object.
     */
-   getCommitStatus: function(repo, sha) {
+   getCommitStatuses: function(repo, sha) {
       var q_select = '\
          SELECT * FROM commit_statuses \
          WHERE commit = ? AND repo = ?';
 
       return db.query(q_select, [sha, repo]).then(function(rows) {
-         if (rows.length === 1) {
-            return Status.getFromDB(rows[0]);
-         } else {
-            return null;
-         }
+         return rows.map(row => Status.getFromDB(row));
       });
    },
 

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -365,8 +365,9 @@ function getCommit(repo, sha) {
 
 function getCommitStatuses(repo, ref) {
    debug("Getting commit status for %s", ref);
-   return rateLimit(github.repos.getStatuses)(params({ ref }, repo))
-                      .then(res => res.data)
+   return rateLimit(github.repos.getCombinedStatusForRef)(params({ ref }, repo))
+      .then(res => res.data.statuses)
+      .then(statuses => statuses || [])
 }
 
 /**

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -112,7 +112,7 @@ module.exports = {
       var reviewComments = getPullReviewComments(repo, githubPull.number);
       var comments = getIssueComments(repo, githubPull.number);
       var headCommit = getCommit(repo, githubPull.head.sha);
-      var commitStatus = getCommitStatus(repo, githubPull.head.sha);
+      var commitStatuses = getCommitStatuses(repo, githubPull.head.sha);
       var events = getIssueEvents(repo, githubPull.number);
       // Only so we have the canonical list of labels.
       var ghIssue = module.exports.getIssue(repo, githubPull.number);
@@ -122,14 +122,14 @@ module.exports = {
       return Promise.all([reviewComments,
                           comments,
                           headCommit,
-                          commitStatus,
+                          commitStatuses,
                           events,
                           ghIssue])
        .then(function(results) {
          var reviewComments = results[0],
              comments       = results[1],
              headCommit     = results[2],
-             commitStatus   = results[3],
+             commitStatuses = results[3],
              events         = results[4],
              ghIssue        = results[5];
 
@@ -169,22 +169,21 @@ module.exports = {
             return new Comment(commentData);
          }));
 
-         // Status object.
-         let status = null;
-         if (commitStatus) {
-            status = new Status({
+         let statuses = commitStatuses.map(function(commitStatus) {
+            return new Status({
                repo:          repo,
                sha:           githubPull.head.sha,
                state:         commitStatus.state,
                description:   commitStatus.description,
-               target_url:    commitStatus.target_url
+               target_url:    commitStatus.target_url,
+               context:       commitStatus.context,
             });
-         }
+         });
 
          // Array of Label objects.
          const labels = getLabelsFromEvents(events, ghIssue);
 
-         const pull = Pull.fromGithubApi(githubPull, signatures, comments, status, labels);
+         const pull = Pull.fromGithubApi(githubPull, signatures, comments, statuses, labels);
          return pull.syncToIssue();
       });
    },
@@ -364,11 +363,10 @@ function getCommit(repo, sha) {
                       .then(res => res.data);
 }
 
-function getCommitStatus(repo, ref) {
+function getCommitStatuses(repo, ref) {
    debug("Getting commit status for %s", ref);
    return rateLimit(github.repos.getStatuses)(params({ ref }, repo))
                       .then(res => res.data)
-                      .then(statuses => statuses.length ? statuses[0] : null);
 }
 
 /**

--- a/migrations/0011-add-build-status-context.sql
+++ b/migrations/0011-add-build-status-context.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `commit_statuses`
+ADD COLUMN `context` varchar(255) NOT NULL DEFAULT 'default',
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (repo, `commit`, context);

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS `commit_statuses` (
   `state` enum('pending','success','error','failure') NOT NULL,
   `description` varchar(255) NOT NULL,
   `log_url` varchar(255) NOT NULL,
+  `context` varchar(255) NOT NULL,
   PRIMARY KEY (`repo`,`commit`),
   KEY `commit_statuses_state` (`state`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/models/db_status.js
+++ b/models/db_status.js
@@ -10,7 +10,8 @@ function DBStatus(status) {
       commit: statusData.sha,
       state: statusData.state,
       description: statusData.description,
-      log_url: statusData.target_url
+      log_url: statusData.target_url,
+      context: statusData.context,
    };
 }
 

--- a/models/pull.js
+++ b/models/pull.js
@@ -11,7 +11,7 @@ function Pull(data, signatures, comments, commitStatuses, labels) {
    this.data = data;
    this.signatures = signatures || [];
    this.comments = comments || [];
-   this.commitStatuses = commitStatuses || [];
+   this.commitStatuses = commitStatuses;
    this.labels = labels || [];
 
    // If github pull-data, parse the body for the cr and qa req... else

--- a/models/pull.js
+++ b/models/pull.js
@@ -114,7 +114,7 @@ Pull.prototype.isOpen = function() {
  *    'deploy_block'  : An array containing the last 'deploy_block' signature if pull is deploy blocked,
  *                       or an empty array
  *    'ready'         : A boolean indicating whether the pull is ready to be deployed.
- *    'commit_statuses' : A Status object or null.
+ *    'commit_statuses' : An array of Status objects
  * }
  */
 Pull.prototype.getStatus = function getStatus() {

--- a/models/pull.js
+++ b/models/pull.js
@@ -7,11 +7,11 @@ var debug = require('../lib/debug')('pulldasher:pull');
 var DBPull = require('./db_pull');
 var getLogin = require('../lib/get-user-login');
 
-function Pull(data, signatures, comments, commitStatus, labels) {
+function Pull(data, signatures, comments, commitStatuses, labels) {
    this.data = data;
    this.signatures = signatures || [];
    this.comments = comments || [];
-   this.commitStatus = commitStatus;
+   this.commitStatuses = commitStatuses || [];
    this.labels = labels || [];
 
    // If github pull-data, parse the body for the cr and qa req... else
@@ -114,7 +114,7 @@ Pull.prototype.isOpen = function() {
  *    'deploy_block'  : An array containing the last 'deploy_block' signature if pull is deploy blocked,
  *                       or an empty array
  *    'ready'         : A boolean indicating whether the pull is ready to be deployed.
- *    'commit_status' : A Status object or null.
+ *    'commit_statuses' : A Status object or null.
  * }
  */
 Pull.prototype.getStatus = function getStatus() {
@@ -129,7 +129,7 @@ Pull.prototype.getStatus = function getStatus() {
       'allCR' : this.getAllSignatures('CR'),
       'dev_block'    : this.getSignatures('dev_block'),
       'deploy_block' : this.getSignatures('deploy_block'),
-      'commit_status' : this.commitStatus
+      'commit_statuses' : this.commitStatuses
    };
 
    status['ready'] =
@@ -160,7 +160,7 @@ Pull.parseBody = function(body) {
    return bodyTags;
 };
 
-Pull.fromGithubApi = function(data, signatures, comments, commitStatus, labels) {
+Pull.fromGithubApi = function(data, signatures, comments, commitStatuses, labels) {
    data = {
       repo: data.base.repo.full_name,
       number: data.number,
@@ -194,14 +194,14 @@ Pull.fromGithubApi = function(data, signatures, comments, commitStatus, labels) 
       }
    };
 
-   return new Pull(data, signatures, comments, commitStatus, labels);
+   return new Pull(data, signatures, comments, commitStatuses, labels);
 };
 
 /**
  * Takes an object representing a DB row, and returns an instance of this
  * Pull object.
  */
-Pull.getFromDB = function(data, signatures, comments, commitStatus, labels) {
+Pull.getFromDB = function(data, signatures, comments, commitStatuses, labels) {
    var pullData = {
       repo: data.repo,
       number: data.number,
@@ -236,7 +236,7 @@ Pull.getFromDB = function(data, signatures, comments, commitStatus, labels) {
       qa_req: data.qa_req
    };
 
-   return new Pull(pullData, signatures, comments, commitStatus, labels);
+   return new Pull(pullData, signatures, comments, commitStatuses, labels);
 };
 
 module.exports = Pull;

--- a/models/status.js
+++ b/models/status.js
@@ -7,7 +7,8 @@ function Status(data) {
       sha: data.sha,
       target_url: data.target_url,
       description: data.description,
-      state: data.state
+      state: data.state,
+      context: data.context,
    };
 }
 
@@ -21,7 +22,8 @@ Status.getFromDB = function(data) {
       sha:           data.commit,
       target_url:    data.log_url,
       description:   data.description,
-      state:         data.state
+      state:         data.state,
+      context:       data.context,
    });
 };
 

--- a/public/js/Pull.js
+++ b/public/js/Pull.js
@@ -111,8 +111,8 @@ _.extend(Pull.prototype, {
    },
 
    build_status: function() {
-      var status = this.status.commit_status;
-      return status && status.data.state;
+      var statuses = this.status.commit_statuses || [];
+      return statuses[0] && statuses[0].data.state;
    },
 
    build_failed: function() {
@@ -125,7 +125,7 @@ _.extend(Pull.prototype, {
    },
 
    build_unavailable: function() {
-      return this.status.commit_status === null;
+      return this.status.commit_statuses.length == 0;
    },
 
    refresh: function() {

--- a/public/js/Pull.js
+++ b/public/js/Pull.js
@@ -110,22 +110,23 @@ _.extend(Pull.prototype, {
       return _.findWhere(this.labels, {title: labelName});
    },
 
-   build_status: function() {
-      var statuses = this.status.commit_statuses || [];
-      return statuses[0] && statuses[0].data.state;
+   build_statuses: function() {
+      return this.status.commit_statuses || [];
    },
 
    build_failed: function() {
-      var status = this.build_status();
-      return status === 'failure' || status === 'error';
+      return this.build_statuses().some(
+         ({data}) => data.status === 'failure' || data.status === 'error');
    },
 
    build_succeeded: function() {
-      return this.build_status() === 'success';
+      const statuses = this.build_statuses();
+      return statuses.length && statuses.every(
+         ({data}) => data.status === 'success');
    },
 
    build_unavailable: function() {
-      return this.status.commit_statuses.length == 0;
+      return this.status.commit_statuses.length === 0;
    },
 
    refresh: function() {

--- a/views/standard/less/components/pull.less
+++ b/views/standard/less/components/pull.less
@@ -116,12 +116,15 @@
       bottom: 10px;
       border-radius: 3px;
       display: flex;
-      justify-content: space-between;
+      justify-content: flex-start;
       flex-direction: column;
    }
 
    .build_status_link {
+      width: 100%;
       height: 100%;
+      border-radius: 5px;
+      margin: 2px 0;
    }
 
    .build-state-pending {

--- a/views/standard/less/components/pull.less
+++ b/views/standard/less/components/pull.less
@@ -108,13 +108,20 @@
 }
 
 .build_status {
-   .build_status_link {
+   .build_status_container {
       position: absolute;
       width: 4px;
       top: 10px;
       left: 7px;
       bottom: 10px;
       border-radius: 3px;
+      display: flex;
+      justify-content: space-between;
+      flex-direction: column;
+   }
+
+   .build_status_link {
+      height: 100%;
    }
 
    .build-state-pending {

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -219,8 +219,9 @@ export default {
       signatureStatus(pull, node, 'QA', required, pull.qa_signatures);
    },
    build_status: function status(pull, node) {
-      if (pull.status.commit_status) {
-         var commit_status = pull.status.commit_status.data;
+      let status = pull.status.commit_statuses[0];
+      if (status) {
+         var commit_status = status.data;
          var title = commit_status.description;
          var url   = commit_status.target_url;
 

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -219,21 +219,23 @@ export default {
       signatureStatus(pull, node, 'QA', required, pull.qa_signatures);
    },
    build_status: function status(pull, node) {
-      let status = pull.status.commit_statuses[0];
-      if (status) {
-         var commit_status = status.data;
-         var title = commit_status.description;
-         var url   = commit_status.target_url;
+      const statuses = pull.status.commit_statuses;
+      if (statuses && statuses.length) {
+         const statusContainer = $('<div class="build_status_container"></div>');
+         statusContainer.append(statuses.map((status) => {
+            const commit_status = status.data;
+            const title = commit_status.description;
+            const url   = commit_status.target_url;
 
-         var link = $('<a target="_blank" class="build_status_link" data-toggle="tooltip" data-placement="top"></a>');
-         link.attr('href', url);
-         link.attr('title', title);
+            const link = $('<a target="_blank" class="build_status_link" data-toggle="tooltip" data-placement="top"></a>');
+            link.attr('href', url);
+            link.attr('title', commit_status.context + ": " + title);
+            link.addClass('build-state-' + commit_status.state);
+            link.tooltip();
+            return link;
+         }));
 
-         node.append(link);
-
-         link.addClass('build-state-' + commit_status.state);
-
-         link.tooltip();
+         node.append(statusContainer);
       }
    },
    user_icon: function user_icon(pull, node) {

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -225,7 +225,9 @@ export default {
          var title = commit_status.description;
          var url   = commit_status.target_url;
 
-         var link = $('<a target="_blank" class="build_status_link" data-toggle="tooltip" data-placement="top" title="' + title + '" href="' + url + '"></a>');
+         var link = $('<a target="_blank" class="build_status_link" data-toggle="tooltip" data-placement="top"></a>');
+         link.attr('href', url);
+         link.attr('title', title);
 
          node.append(link);
 

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -222,7 +222,8 @@ export default {
       const statuses = pull.status.commit_statuses;
       if (statuses && statuses.length) {
          const statusContainer = $('<div class="build_status_container"></div>');
-         statusContainer.append(statuses.map((status) => {
+         const sortedStatuses = statuses.sort(compareByContext);
+         statusContainer.append(sortedStatuses.map((status) => {
             const commit_status = status.data;
             const title = commit_status.description;
             const url   = commit_status.target_url;
@@ -294,3 +295,13 @@ export default {
       });
    }
 };
+
+function compareByContext(statusA, statusB) {
+   if (statusA.data.context < statusB.data.context) {
+     return -1;
+   }
+   if (statusA.data.context > statusB.data.context) {
+     return 1;
+   }
+   return 0;
+}

--- a/views/standard/spec/pageIndicators.js
+++ b/views/standard/spec/pageIndicators.js
@@ -109,7 +109,8 @@ export default {
          // Pull the org/repo string from the first frozen pull.
          var repo = frozen[0].repo;
          var label = 'Cryogenic Storage';
-         var link = $('<a target="_blank" href="https://www.github.com/' + repo + '/labels/' + label + '"></a>');
+         var link = $('<a target="_blank" ></a>');
+         link.attr('href', 'https://www.github.com/' + repo + '/labels/' + label);
          node.wrapInner(link);
       }
    },


### PR DESCRIPTION
Support multiple statuses per commit:

* Injest them from the webhooks
* Save them to the DB
* Load them from the DB
* Request them from the API
* Maintain them in the memory model
* Update the UI
  * Split the existing green/red CI status bar into vertical pills
    with one per status

![image](https://user-images.githubusercontent.com/26855/68884191-7e925800-06c7-11ea-8b2f-2ff757b9dff1.png)

Closes #72