### PR TITLE
Allow overriding the config path from the ENV

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,6 @@
-var config = require('./config'),
+var configPath = process.env.CONFIG_PATH || './config';
+
+var config = require(configPath),
     express = require('express'),
     partials = require('express-partials'),
     bodyParser = require('body-parser'),


### PR DESCRIPTION
In order to mount the pulldasher configuration as a secret, we need to be able to mount a volume, not a single file. The `config.js` file was hardcoded here to `/opt/pulldasher/config.js`. Let's allow optionally specifying the path on the environment.

cr_req 1
qa_req 0

CC @danielbeardsley