### PR TITLE
Pull Diff: store data in DB

### DIFF
--- a/migrations/0012-add-pull-diff-info.sql
+++ b/migrations/0012-add-pull-diff-info.sql
@@ -1,4 +1,5 @@
 ALTER TABLE `pulls`
+ADD COLUMN `commits` int(11) unsigned DEFAULT NULL,
 ADD COLUMN `additions` int(11) unsigned DEFAULT NULL,
 ADD COLUMN `deletions` int(11) unsigned DEFAULT NULL,
 ADD COLUMN `changed_files` int(11) unsigned DEFAULT NULL;

--- a/migrations/0012-add-pull-diff-info.sql
+++ b/migrations/0012-add-pull-diff-info.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `pulls`
+ADD COLUMN `additions` int(11) unsigned DEFAULT NULL,
+ADD COLUMN `deletions` int(11) unsigned DEFAULT NULL,
+ADD COLUMN `changed_files` int(11) unsigned DEFAULT NULL;

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -135,6 +135,7 @@ CREATE TABLE IF NOT EXISTS `pulls` (
   `closes` int(10) unsigned DEFAULT NULL,
   `connects` int(10) unsigned DEFAULT NULL,
   `difficulty` int(11) DEFAULT NULL,
+  `commits` int(11) unsigned DEFAULT NULL,
   `additions` int(11) unsigned DEFAULT NULL,
   `deletions` int(11) unsigned DEFAULT NULL,
   `changed_files` int(11) unsigned DEFAULT NULL,

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -135,6 +135,9 @@ CREATE TABLE IF NOT EXISTS `pulls` (
   `closes` int(10) unsigned DEFAULT NULL,
   `connects` int(10) unsigned DEFAULT NULL,
   `difficulty` int(11) DEFAULT NULL,
+  `additions` int(11) unsigned DEFAULT NULL,
+  `deletions` int(11) unsigned DEFAULT NULL,
+  `changed_files` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`repo`,`number`),
   KEY `pulls_state` (`state`),
   KEY `pulls_repo` (`repo`)

--- a/models/db_pull.js
+++ b/models/db_pull.js
@@ -27,6 +27,7 @@ function DBPull(pull) {
       qa_req: pullData.qa_req,
       closes: pullData.closes,
       connects: pullData.connects,
+      commits: pullData.commits,
       additions: pullData.additions,
       deletions: pullData.deletions,
       changed_files: pullData.changed_files

--- a/models/db_pull.js
+++ b/models/db_pull.js
@@ -26,7 +26,10 @@ function DBPull(pull) {
       cr_req: pullData.cr_req,
       qa_req: pullData.qa_req,
       closes: pullData.closes,
-      connects: pullData.connects
+      connects: pullData.connects,
+      additions: pullData.additions,
+      deletions: pullData.deletions,
+      changed_files: pullData.changed_files
    };
 }
 

--- a/models/pull.js
+++ b/models/pull.js
@@ -191,7 +191,10 @@ Pull.fromGithubApi = function(data, signatures, comments, commitStatuses, labels
       },
       user: {
          login: getLogin(data.user)
-      }
+      },
+      additions: data.additions,
+      deletions: data.deletions,
+      changed_files: data.changed_files
    };
 
    return new Pull(data, signatures, comments, commitStatuses, labels);

--- a/models/pull.js
+++ b/models/pull.js
@@ -192,6 +192,7 @@ Pull.fromGithubApi = function(data, signatures, comments, commitStatuses, labels
       user: {
          login: getLogin(data.user)
       },
+      commits: data.commits,
       additions: data.additions,
       deletions: data.deletions,
       changed_files: data.changed_files


### PR DESCRIPTION
This will give us the ability to track `additions`, `deletions`, and
`changed_files` on pulls.

QA
----
I ran a local instance of pulldasher and confirmed that these fields
were being filled in in the `pulls` table for new pulls. Anything else
we should check?