### PR TITLE
config.repos: normalize repo list on load

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ var config = require('./lib/config-loader'),
     mainController = require('./controllers/main'),
     hooksController = require('./controllers/githubHooks'),
     reqLogger = require('./lib/debug')('pulldasher:server:request'),
+    utils = require('./lib/utils'),
     debug = require('./lib/debug')('pulldasher');
 
 var app = express();
@@ -49,9 +50,9 @@ authManager.setupRoutes(app);
 app.get('/',            mainController.index);
 app.post('/hooks/main', hooksController.main);
 
-config.repos.forEach(function(repo) {
+utils.forEachRepo(function(repo) {
    // Load open pulls from the DB so we don't start blank.
-   dbManager.getOpenPulls(repo.name).then(function(pulls) {
+   dbManager.getOpenPulls(repo).then(function(pulls) {
       pullQueue.pause();
       pulls.forEach(function(pull) {
          pullManager.updatePull(pull);

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -1,3 +1,13 @@
 var configPath = process.env.CONFIG_PATH || '../config';
-module.exports = require(configPath);
+const config = require(configPath);
+module.exports  = config;
 
+config.repos = config.repos.map(normalizeRepo);
+
+function normalizeRepo(repo) {
+   if (typeof repo == 'string') {
+      return {name: repo};
+   } else {
+      return repo;
+   }
+}

--- a/lib/pull-manager.js
+++ b/lib/pull-manager.js
@@ -39,7 +39,7 @@ function sendInitialData(socket) {
    debug('Emitting `initialize`: %s pulls altogether', pulls.length);
    socket.emit('initialize', {
       pulls: _.invoke(pulls, 'toObject'),
-      repos: config.repos.map(normalizeRepo),
+      repos: config.repos,
    });
 }
 
@@ -65,14 +65,6 @@ function getPull(repo, number) {
    return _.find(pulls, function(pull) {
       return pull.data.repo === repo && Number(pull.data.number) === Number(number);
    });
-}
-
-function normalizeRepo(repo) {
-   if (typeof repo == 'string') {
-      return {name: repo};
-   } else {
-      return repo;
-   }
 }
 
 pullQueue.on('pullsChanged', function(pulls) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,7 +45,7 @@ module.exports = {
       args = args || [];
       args.unshift(null);
       var allRepoMap = function(currentRepo) {
-         args[0] = currentRepo;
+         args[0] = currentRepo.name;
          return singleRepoLambda.apply(this, args);
       };
       return Promise.all(config.repos.map(allRepoMap))


### PR DESCRIPTION
In a previous pull, config.repos learned to handle an array of objects
instead of just an array of strings. Not all usages of the config.repos
setting were updated to handle the different ways of representing the
data.

Instead of handling both formats in each usage, let's normalize when
loading the config.

Connect #167