### PR TITLE
Support more emojis in signoffs

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -1,7 +1,8 @@
 var port = process.env.PORT || 3000;
 
-// Support text emojis and almost all unicode emojis / symbols
-var emoji = "[\u2190-\u2BFF]|\ud83c[\udf00-\udfff]|\ud83d([\udc00-\ude4f]|[\ude80-\udeff])";
+// Support text emojis and all unicode emojis / symbols (as of Dec 2018)
+// See: https://www.regextester.com/106421
+var emoji = "(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])";
 var emojiText = ":[^\n:]+:";
 var signature = "(" + emojiText + '|' + emoji + ")";
 


### PR DESCRIPTION
QA
---
Copy this new regex to from the example config to the real config, and
make sure it:
 - works with emojis that our current regex doesn't like 🪂
 - doesn't match things that aren't emojis

cr_req 1

CC @ianrohde

On Deploy
---
Copy this new regex to from the example config to the real config.

Closes iFixit/pulldasher#176