### PR TITLE
Temporarily revert jQuery bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5108,9 +5108,9 @@
       "optional": true
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-cookie": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "express": "^4.17.1",
     "express-partials": "0.1.1",
     "express-session": "^1.17.0",
-    "jquery": "^3.5.0",
+    "jquery": "^3.4.1",
     "js-cookie": "^2.2.1",
     "mysql": "^2.17.1",
     "notify-queue": "0.0.5",


### PR DESCRIPTION
Background
===

@davidrans tried deploying his recent change #177 but we forgot about an unresolved rollback that happened a month or two ago.

Let's look into why the jQuery bump caused issues, but let's run the
other recent changes in the mean time.

This should allow us to use the most recent changes aside from those in https://github.com/iFixit/pulldasher/pull/173

QA
===

Run this branch and see if you can spot any immediately obvious problems. If there's nothing to glaring, let's merge this and let it run in the wild.