### PR TITLE
Allow one signature per person

### DIFF
--- a/public/js/Pull.js
+++ b/public/js/Pull.js
@@ -27,18 +27,13 @@ _.extend(Pull.prototype, {
             if (!users[signature.data.user.id]) {
                if (signature.data.active) {
                   groups.current.push(signature);
-                  users[signature.data.user.id] = true;
-
-                  if (utils.mySig(signature)) {
-                     groups.user = signature;
-                  }
                } else {
                   groups.old.push(signature);
-                  users[signature.data.user.id] = true;
+               }
+               users[signature.data.user.id] = true;
 
-                  if (utils.mySig(signature)) {
-                     groups.user = signature;
-                  }
+               if (utils.mySig(signature)) {
+                  groups.user = signature;
                }
             }
          });

--- a/public/js/Pull.js
+++ b/public/js/Pull.js
@@ -24,19 +24,21 @@ _.extend(Pull.prototype, {
          groups.user = null;
 
          signatures.forEach(function(signature) {
-            if (signature.data.active) {
-               groups.current.push(signature);
-               users[signature.data.user.id] = true;
+            if (!users[signature.data.user.id]) {
+               if (signature.data.active) {
+                  groups.current.push(signature);
+                  users[signature.data.user.id] = true;
 
-               if (utils.mySig(signature)) {
-                  groups.user = signature;
-               }
-            } else if (!users[signature.data.user.id]) {
-               groups.old.push(signature);
-               users[signature.data.user.id] = true;
+                  if (utils.mySig(signature)) {
+                     groups.user = signature;
+                  }
+               } else {
+                  groups.old.push(signature);
+                  users[signature.data.user.id] = true;
 
-               if (utils.mySig(signature)) {
-                  groups.user = signature;
+                  if (utils.mySig(signature)) {
+                     groups.user = signature;
+                  }
                }
             }
          });

--- a/public/js/Pull.js
+++ b/public/js/Pull.js
@@ -24,17 +24,20 @@ _.extend(Pull.prototype, {
          groups.user = null;
 
          signatures.forEach(function(signature) {
-            if (!users[signature.data.user.id]) {
-               if (signature.data.active) {
-                  groups.current.push(signature);
-               } else {
-                  groups.old.push(signature);
-               }
-               users[signature.data.user.id] = true;
+            if (users[signature.data.user.id]) {
+               return;
+            }
 
-               if (utils.mySig(signature)) {
-                  groups.user = signature;
-               }
+            if (signature.data.active) {
+               groups.current.push(signature);
+            } else {
+               groups.old.push(signature);
+            }
+
+            users[signature.data.user.id] = true;
+
+            if (utils.mySig(signature)) {
+               groups.user = signature;
             }
          });
 


### PR DESCRIPTION
Let's restrict the number of signatures each person can make to one. This will be slightly more bother when carrying over a CR, but it will reduce the risk of accidentally deploying a pull which only one person has signed off on.

We encountered an incident where a person signed off twice, once before a commit was pushed and once after, but because the commit date was before the first signoff date, both signoffs were considered valid. The problem with a signoff not being invalidated by a commit which is pushed after the signoff is still not solved, but this change at least reduces the risk of such an incident resulting in insufficiently-reviewed code being deployed.