### PR TITLE
github rate limit: use new method of getting headers

### DIFF
--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -86,10 +86,16 @@ function startDrainer() {
    }
 }
 
+/**
+ * Returns time in ms to wait before the next request. There's a built-in
+ * assumption that the caller will be saturating the ratelimit. We return
+ * an interval such that you can continue to make requests spaced at this
+ * interval and never hit the limit.
+ */
 function interval() {
    var requestsRemaining = Math.max(1, remaining);
-   // Always underconsume, and leave a minute's worth of requests remaining
-   // just in case our clock drifts from githubs
-   var timeTillReset = Math.max(1, (60 + resetAt) * 1000 - Date.now());
+   // Always underconsume, and leave a bit of a buffer by pretending the rate
+   // is running out earlier.
+   var timeTillReset = Math.max(1, (resetAt + 500) * 1000 - Date.now());
    return timeTillReset / requestsRemaining;
 }

--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -34,8 +34,10 @@ function throttleRequest() {
    if (remaining !== null && remaining < chokePoint) {
       return new Promise(function (resolve, reject) {
          queue(resolve);
+         debug("Request queued because remaining (%s) is less than choke-point (%s). Queue-length: %s ", remaining, chokePoint, requestQueue.length);
       });
    }
+   debug("Not throttling requests because choke-point (%s) not hit yet (%s)", chokePoint, remaining);
    return Promise.resolve();
 }
 
@@ -62,7 +64,11 @@ function drainOne() {
       var resolve = requestQueue.shift();
       resolve();
       var delay = interval();
-      debug("Delayed request: %s (ms)", delay);
+      if (requestQueue.length) {
+         debug("Executed request from queue, next request in %s ms", delay);
+      } else {
+         debug("Executed request from queue, queue is now empty");
+      }
       drainer = setTimeout(drainOne, delay);
    } else {
       drainer = null;

--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -45,10 +45,11 @@ function throttleRequest() {
  * Can be injected in a .then() chain and won't change the resolved value
  */
 function captureRateLimitInfo(response) {
-   if (response && response.meta) {
-      remaining = Number(response.meta['x-ratelimit-remaining']);
-      if (response.meta['x-ratelimit-reset']) {
-         resetAt = Number(response.meta['x-ratelimit-reset']);
+   var headers = response && response.headers;
+   if (headers && headers['x-ratelimit-remaining']) {
+      remaining = Number(headers['x-ratelimit-remaining']);
+      if (headers['x-ratelimit-reset']) {
+         resetAt = Number(headers['x-ratelimit-reset']);
       }
       debug("Response received, requests remaining: %s reset at: %s", remaining, resetAt);
    }

--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -48,6 +48,7 @@ function throttleRequest() {
  */
 function captureRateLimitInfo(response) {
    var headers = response && response.headers;
+   headers = headers || response.meta;
    if (headers && headers['x-ratelimit-remaining']) {
       remaining = Number(headers['x-ratelimit-remaining']);
       if (headers['x-ratelimit-reset']) {


### PR DESCRIPTION
After bumping the ocktokit version we didn't realize the method of
extracting the headers (for ratelimit) had changed.

CC @addison-grant

Closes iFixit/pulldasher#184