### PR TITLE
Remove the frozen indicator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,6 @@ Two query string parameters are available to filter the displayed pulls:
 
    ```ex. https://pulldasher.example.com?milestone=site-redesign,12/5,12/19```
 
-### Frozen Pulls
-When you assign the `Cryogenic Storage` label to a pull, Pulldasher will not
-display it in the main window. Instead, it will be added to the count of "Frozen"
-pulls, visible in the top-left corner. This allows inactive pulls to be removed
-from the main view, rather than taking up space.
-
 ## Architecture
 When first started, the Pulldasher server fetches information about the current
 pulls in the repo from GitHub. It then monitors GitHub hooks for updated

--- a/views/README.md
+++ b/views/README.md
@@ -24,8 +24,7 @@ Within the `standard` directory, you should find the following things:
 ## Making changes
 First, a bit of terminology is in order: We call the small icons that appear on
 a pull _indicators_. By similarity of purpose and implementation, we call the
-parts that display information like the total number of open pulls and the
-number of frozen pulls _page indicators_.
+parts that display information like the total number of open pulls _page indicators_.
 
 Okay, now a guide on where to look to make a change:
 * If you want to change the appearance of part of pulldasher, look at the `less`

--- a/views/standard/less/components/header.less
+++ b/views/standard/less/components/header.less
@@ -116,10 +116,6 @@
       a {
          color: var(--global-indicator-text-link) !important;
       }
-
-      &.frozen_count:hover {
-         text-decoration: underline;
-      }
    }
 }
 

--- a/views/standard/spec/pageIndicators.js
+++ b/views/standard/spec/pageIndicators.js
@@ -95,25 +95,6 @@ export default {
       node.wrapInner('<span class="number"></span>');
       node.append(' Open');
    },
-   frozen_count: function(pulls, node) {
-      var frozen = pulls.filter(function(pull) {
-         return pull.hasLabel('Cryogenic Storage') && pull.state === 'open';
-      });
-
-      node.text(frozen.length);
-      node.wrapInner('<span class="number"></span>');
-      node.append(' Frozen');
-
-      // If we have frozen pulls, make the count a link.
-      if (frozen.length) {
-         // Pull the org/repo string from the first frozen pull.
-         var repo = frozen[0].repo;
-         var label = 'Cryogenic Storage';
-         var link = $('<a target="_blank" ></a>');
-         link.attr('href', 'https://www.github.com/' + repo + '/labels/' + label);
-         node.wrapInner(link);
-      }
-   },
    cr_leaderboard: function(pulls, node) {
       summarize(pulls, node, "CR", function(pull) {
          return pull.status.allCR;


### PR DESCRIPTION
The frozen indicator has been targeted for termination.  Let's get that done.

Besides falling into disuse for the most part, it doesn't work correctly with multiple repos either.  The link is built from the repo  of the first frozen pull it comes across.  On the `comior` instance it appears to point to a dead repo?

Closes #136 