### PR TITLE
Pulls: Add age indicator

### DIFF
--- a/views/standard/html/pull.html
+++ b/views/standard/html/pull.html
@@ -18,5 +18,6 @@
          <div class="indicators"></div>
          <div class="user-col user_icon"></div>
       </div>
+      <div class='age'></div>
    </div>
 </a>

--- a/views/standard/less/components/pull.less
+++ b/views/standard/less/components/pull.less
@@ -382,6 +382,11 @@
    }
 }
 
+.age_container {
+   max-width: 100%;
+   width: fit-content;
+}
+
 .user_icon {
    float: left;
    margin-right: 5px;

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -311,7 +311,7 @@ export default {
 function getAgeColor(days) {
    switch (Math.floor(days / 3)) {
       case 0: return 'green';
-      case 1: return '#fabd02';
+      case 1: return '#ffe62f';
       case 2: return 'orange';
       default: return 'red';
    }

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -284,13 +284,13 @@ export default {
    age: function age(pull, node) {
       const timeDifference = Date.now() - new Date(pull.created_at).getTime();
       const daysSinceCreation = Math.ceil(timeDifference / (1000 * 3600 * 24));
-      const numDots = Math.min(daysSinceCreation, 20);
+      const numDots = Math.min(daysSinceCreation, 30);
       const dot = "•";
       const daysInDots = dot.repeat(numDots);
       const severityColor  = getAgeColor(daysSinceCreation);
 
       var ageContainer = $(`<div class="age_container" style="color:${severityColor}">${daysInDots}</div>`);
-      utils.addTooltip(ageContainer, `Age: ${daysSinceCreation}`);
+      utils.addTooltip(ageContainer, `Age: ${daysSinceCreation}`, 'right');
       node.append(ageContainer);
    },
 

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -284,7 +284,7 @@ export default {
    age: function age(pull, node) {
       const timeDifference = Date.now() - new Date(pull.created_at).getTime();
       const daysSinceCreation = Math.ceil(timeDifference / (1000 * 3600 * 24));
-      const numDots = daysSinceCreation < 21 ? daysSinceCreation : 20;
+      const numDots = Math.min(daysSinceCreation, 20);
       const dot = "•";
       const daysInDots = dot.repeat(numDots);
       const severityColor  = getAgeColor(daysSinceCreation);
@@ -311,7 +311,7 @@ export default {
 function getAgeColor(days) {
    switch (Math.floor(days / 3)) {
       case 0: return 'green';
-      case 1: return 'yellow';
+      case 1: return '#fabd02';
       case 2: return 'orange';
       default: return 'red';
    }

--- a/views/standard/spec/indicators.js
+++ b/views/standard/spec/indicators.js
@@ -281,6 +281,18 @@ export default {
          node.append(tag);
       });
    },
+   age: function age(pull, node) {
+      const timeDifference = Date.now() - new Date(pull.created_at).getTime();
+      const daysSinceCreation = Math.ceil(timeDifference / (1000 * 3600 * 24));
+      const numDots = daysSinceCreation < 21 ? daysSinceCreation : 20;
+      const dot = "•";
+      const daysInDots = dot.repeat(numDots);
+      const severityColor  = getAgeColor(daysSinceCreation);
+
+      var ageContainer = $(`<div class="age_container" style="color:${severityColor}">${daysInDots}</div>`);
+      utils.addTooltip(ageContainer, `Age: ${daysSinceCreation}`);
+      node.append(ageContainer);
+   },
 
    // Here's an interesting duck! This indicator actually adds the event
    // handler to _the refresh button_ on each pull. If you look at the pull
@@ -295,6 +307,15 @@ export default {
       });
    }
 };
+
+function getAgeColor(days) {
+   switch (Math.floor(days / 3)) {
+      case 0: return 'green';
+      case 1: return 'yellow';
+      case 2: return 'orange';
+      default: return 'red';
+   }
+}
 
 function compareByContext(statusA, statusB) {
    if (statusA.data.context < statusB.data.context) {


### PR DESCRIPTION
We want to be able to tell how hold a pull is at a glance. This adds the
indicator as well as adds it to the pull element.

Note: We cap the number of dots at 20 but the tooltip still shows the 
correct number of days.

![image](https://user-images.githubusercontent.com/29667789/116633186-b5851980-a90d-11eb-9b47-23c643108685.png)

QA:
--
I currently have it set up on https://pulldasher-dev.cominor.com.  Play
around with it! You could open a test pull to ensure it adds the proper
dots.

cc @addison-grant (We both worked on this).