### PR TITLE
Pull Request Reviews: parse signoffs out of GitHub reviews

### DIFF
--- a/bin/dump-schema
+++ b/bin/dump-schema
@@ -14,6 +14,7 @@ mysqldump "$@" \
    pull_labels \
    pull_signatures \
    pulls \
+   reviews \
    > $SCHEMA_FILE
 
 sed -i -e "s/CREATE TABLE/CREATE TABLE IF NOT EXISTS/" $SCHEMA_FILE

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -6,12 +6,14 @@ var _ = require('underscore'),
     DBStatus = require('../models/db_status'),
     DBSignature = require('../models/db_signature'),
     DBComment = require('../models/db_comment'),
+    DBReview = require('../models/db_review'),
     DBLabel = require('../models/db_label'),
     Pull = require('../models/pull'),
     Issue = require('../models/issue'),
     Status = require('../models/status'),
     Signature = require('../models/signature'),
     Comment = require('../models/comment'),
+    Review = require('../models/review'),
     Label = require('../models/label'),
     queue = require('../lib/pull-queue');
 
@@ -144,6 +146,25 @@ var dbManager = module.exports = {
    },
 
    /**
+    * Insert a review into the database, or update the row if
+    * it already exists.
+    */
+   updateReview: function(review) {
+      debug('Calling `updateReview` for review %s in repo %s',
+       review.data.review_id, review.data.repo);
+      var dbReview = new DBReview(review);
+      var number = dbReview.data.number;
+      var repo = dbReview.data.repo;
+
+      return dbReview.save().
+      then(function() {
+         queue.markPullAsDirty(repo, number);
+         debug('updateReview: updated review(%s) on Pull #%s in repo %s',
+          dbReview.data.review_id, number, repo);
+      });
+   },
+
+   /**
     * Insert a signature into the database, invalidate any appropriate old
     * signatures, and return a promise that resolves when both of those
     * DB writes are complete.
@@ -264,16 +285,18 @@ var dbManager = module.exports = {
          var comments       = self.getComments(repo, number);
          var commitStatuses = self.getCommitStatuses(repo, dbPullData.head_sha);
          var labels         = self.getLabels(repo, number);
+         var reviews        = self.getReviews(repo, number);
 
-         return Promise.all([signatures, comments, commitStatuses, labels]).
+         return Promise.all([signatures, comments, commitStatuses, labels, reviews]).
          then(function(resolved) {
             signatures     = resolved[0];
             comments       = resolved[1];
             commitStatuses = resolved[2];
             labels         = resolved[3];
+            reviews        = resolved[4];
 
             debug('getPull: retrieved Pull #%s in repo %s', number, repo);
-            return Pull.getFromDB(dbPullData, signatures, comments,
+            return Pull.getFromDB(dbPullData, signatures, comments, reviews,
              commitStatuses, labels);
          });
       });
@@ -366,6 +389,21 @@ var dbManager = module.exports = {
       return db.query(q_select, [number, repo]).then(function(rows) {
          return rows.map(function(row) {
             return Comment.getFromDB(row);
+         });
+      });
+   },
+
+   /**
+    * Returns a promise which resolves to an array of Review objects.
+    */
+   getReviews: function(repo, number) {
+      var q_select = '\
+         SELECT * FROM reviews \
+         WHERE number = ? AND repo = ?';
+
+      return db.query(q_select, [number, repo]).then(function(rows) {
+         return rows.map(function(row) {
+            return Review.getFromDB(row);
          });
       });
    },

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -61,6 +61,12 @@ var dbManager = module.exports = {
             );
          });
 
+         pull.reviews.forEach(function(review) {
+            updates.push(
+               dbManager.updateReview(review)
+            );
+         });
+
          updates.push(
             dbManager.deleteLabels(pull.data.repo, pull.data.number).then(function() {
                return dbManager.insertLabels(pull.data.repo, pull.labels, pull.data.number);

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -142,16 +142,6 @@ module.exports = {
             var commentSigs = Signature.parseComment(
              comment, repo, githubPull.number);
 
-            // Signoffs from before the most recent commit are no longer active.
-            var headCommitDate = new Date(headCommit.commit.committer.date);
-            commentSigs.forEach(function(signature) {
-               if ((signature.data.type === 'CR' ||
-                signature.data.type === 'QA') &&
-                new Date(signature.data.created_at) < headCommitDate) {
-                  signature.data.active = false;
-               }
-            });
-
             return sigs.concat(commentSigs);
          }, []);
 
@@ -159,18 +149,18 @@ module.exports = {
             var reviewSigs = Signature.parseReview(
              review, repo, githubPull.number);
 
-            // Signoffs from before the most recent commit are no longer active.
-            var headCommitDate = new Date(headCommit.commit.committer.date);
-            reviewSigs.forEach(function(signature) {
-               if ((signature.data.type === 'CR' ||
-                signature.data.type === 'QA') &&
-                new Date(signature.data.created_at) < headCommitDate) {
-                  signature.data.active = false;
-               }
-            });
-
             return sigs.concat(reviewSigs);
          }, commentSignatures);
+
+         // Signoffs from before the most recent commit are no longer active.
+         var headCommitDate = new Date(headCommit.commit.committer.date);
+         signatures.forEach(function(signature) {
+            if ((signature.data.type === 'CR' ||
+             signature.data.type === 'QA') &&
+             new Date(signature.data.created_at) < headCommitDate) {
+               signature.data.active = false;
+            }
+         });
 
          // Array of Comment objects.
          comments = comments.map(function(commentData) {

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -10,6 +10,7 @@ var GithubApi = require('@octokit/rest'),
     Pull = require('../models/pull'),
     Issue = require('../models/issue'),
     Comment = require('../models/comment'),
+    Review = require('../models/review'),
     Label = require('../models/label'),
     Status = require('../models/status'),
     Signature = require('../models/signature'),
@@ -116,6 +117,7 @@ module.exports = {
       var events = getIssueEvents(repo, githubPull.number);
       // Only so we have the canonical list of labels.
       var ghIssue = module.exports.getIssue(repo, githubPull.number);
+      var reviews = getReviews(repo, githubPull.number);
 
       // Returned to the map function. Each element of githubPulls maps to
       // a promise that resolves to a Pull.
@@ -124,17 +126,19 @@ module.exports = {
                           headCommit,
                           commitStatuses,
                           events,
-                          ghIssue])
+                          ghIssue,
+                          reviews])
        .then(function(results) {
          var reviewComments = results[0],
              comments       = results[1],
              headCommit     = results[2],
              commitStatuses = results[3],
              events         = results[4],
-             ghIssue        = results[5];
+             ghIssue        = results[5],
+             reviews        = results[6];
 
          // Array of Signature objects.
-         var signatures = comments.reduce(function(sigs, comment) {
+         var commentSignatures = comments.reduce(function(sigs, comment) {
             var commentSigs = Signature.parseComment(
              comment, repo, githubPull.number);
 
@@ -150,6 +154,23 @@ module.exports = {
 
             return sigs.concat(commentSigs);
          }, []);
+
+         var signatures = reviews.reduce(function(sigs, review) {
+            var reviewSigs = Signature.parseReview(
+             review, repo, githubPull.number);
+
+            // Signoffs from before the most recent commit are no longer active.
+            var headCommitDate = new Date(headCommit.commit.committer.date);
+            reviewSigs.forEach(function(signature) {
+               if ((signature.data.type === 'CR' ||
+                signature.data.type === 'QA') &&
+                new Date(signature.data.created_at) < headCommitDate) {
+                  signature.data.active = false;
+               }
+            });
+
+            return sigs.concat(reviewSigs);
+         }, commentSignatures);
 
          // Array of Comment objects.
          comments = comments.map(function(commentData) {
@@ -169,6 +190,13 @@ module.exports = {
             return new Comment(commentData);
          }));
 
+         reviews = reviews.map(function(reviewData) {
+            reviewData.number = githubPull.number;
+            reviewData.repo = repo;
+
+            return new Review(reviewData);
+         });
+
          let statuses = commitStatuses.map(function(commitStatus) {
             return new Status({
                repo:          repo,
@@ -183,7 +211,7 @@ module.exports = {
          // Array of Label objects.
          const labels = getLabelsFromEvents(events, ghIssue);
 
-         const pull = Pull.fromGithubApi(githubPull, signatures, comments, statuses, labels);
+         const pull = Pull.fromGithubApi(githubPull, signatures, comments, reviews, statuses, labels);
          return pull.syncToIssue();
       });
    },
@@ -349,6 +377,12 @@ function getIssueEvents(repo, number) {
 function getIssueComments(repo, number) {
    debug("Getting comments for issue #%s", number);
    return rateLimit(github.issues.getComments)(params({ number }, repo))
+                       .then(paginate);
+}
+
+function getReviews(repo, number) {
+   debug("Getting reviews for pull #%s", number);
+   return rateLimit(github.pullRequests.listReviews)(params({ number }, repo))
                        .then(paginate);
 }
 

--- a/migrations/0013-add-reviews-table.sql
+++ b/migrations/0013-add-reviews-table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `reviews` (
+  `repo` varchar(255) NOT NULL,
+  `review_id` int(10) unsigned NOT NULL,
+  `number` int(10) unsigned NOT NULL,
+  `body` text NOT NULL,
+  `state` varchar(255) NOT NULL,
+  `user` varchar(255) NOT NULL,
+  `date` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`repo`,`review_id`),
+  KEY `pull` (`number`)
+);

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -144,6 +144,25 @@ CREATE TABLE IF NOT EXISTS `pulls` (
   KEY `pulls_repo` (`repo`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `reviews`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `reviews` (
+  `repo` varchar(255) NOT NULL,
+  `review_id` int(10) unsigned NOT NULL,
+  `number` int(10) unsigned NOT NULL,
+  `body` text NOT NULL,
+  `state` varchar(255) NOT NULL,
+  `user` varchar(255) NOT NULL,
+  `date` int(11) unsigned DEFAULT NULL,
+  PRIMARY KEY (`repo`,`review_id`),
+  KEY `pull` (`number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/models/db_review.js
+++ b/models/db_review.js
@@ -1,0 +1,41 @@
+var utils = require('../lib/utils'),
+    db = require('../lib/db'),
+    getLogin = require('../lib/get-user-login'),
+    debug = require('../lib/debug')('pulldasher:db_review');
+
+/**
+ * Builds an object representation of a row in the DB `reviews` table
+ * from the Review object.
+ */
+function DBReview(review) {
+   var reviewData = review.data;
+   this.data = {
+      repo: reviewData.repo,
+      review_id: reviewData.review_id,
+      number: reviewData.number,
+      body: reviewData.body,
+      state: reviewData.state,
+      user: getLogin(reviewData.user),
+      date: utils.toUnixTime(reviewData.submitted_at)
+   };
+}
+
+DBReview.prototype.save = function() {
+   var reviewData = this.data;
+   var q_update = 'REPLACE INTO reviews SET ?';
+
+   return db.query(q_update, reviewData);
+};
+
+DBReview.delete = function deleteReview(repo, review_id) {
+   debug("deleting %s review %s in repo %s", review_id, repo);
+   var q_delete = 'DELETE FROM reviews \
+                   WHERE `review_id` = ? \
+                     AND `repo` = ?';
+
+   return db.query(q_delete, [review_id, repo]).then(function() {
+      debug('deleted %s review %s in repo %s', review_id, repo);
+   });
+};
+
+module.exports = DBReview;

--- a/models/pull.js
+++ b/models/pull.js
@@ -7,10 +7,11 @@ var debug = require('../lib/debug')('pulldasher:pull');
 var DBPull = require('./db_pull');
 var getLogin = require('../lib/get-user-login');
 
-function Pull(data, signatures, comments, commitStatuses, labels) {
+function Pull(data, signatures, comments, reviews, commitStatuses, labels) {
    this.data = data;
    this.signatures = signatures || [];
    this.comments = comments || [];
+   this.reviews = reviews || [];
    this.commitStatuses = commitStatuses;
    this.labels = labels || [];
 
@@ -160,7 +161,7 @@ Pull.parseBody = function(body) {
    return bodyTags;
 };
 
-Pull.fromGithubApi = function(data, signatures, comments, commitStatuses, labels) {
+Pull.fromGithubApi = function(data, signatures, comments, reviews, commitStatuses, labels) {
    data = {
       repo: data.base.repo.full_name,
       number: data.number,
@@ -198,14 +199,14 @@ Pull.fromGithubApi = function(data, signatures, comments, commitStatuses, labels
       changed_files: data.changed_files
    };
 
-   return new Pull(data, signatures, comments, commitStatuses, labels);
+   return new Pull(data, signatures, comments, reviews, commitStatuses, labels);
 };
 
 /**
  * Takes an object representing a DB row, and returns an instance of this
  * Pull object.
  */
-Pull.getFromDB = function(data, signatures, comments, commitStatuses, labels) {
+Pull.getFromDB = function(data, signatures, comments, reviews, commitStatuses, labels) {
    var pullData = {
       repo: data.repo,
       number: data.number,
@@ -240,7 +241,7 @@ Pull.getFromDB = function(data, signatures, comments, commitStatuses, labels) {
       qa_req: data.qa_req
    };
 
-   return new Pull(pullData, signatures, comments, commitStatuses, labels);
+   return new Pull(pullData, signatures, comments, reviews, commitStatuses, labels);
 };
 
 module.exports = Pull;

--- a/models/review.js
+++ b/models/review.js
@@ -1,0 +1,39 @@
+var utils = require('../lib/utils');
+var getLogin = require('../lib/get-user-login');
+
+/**
+ * A Pull Request review.
+ */
+function Review(data) {
+   this.data = {
+      repo: data.repo,
+      review_id: data.id,
+      number: data.number,
+      body: data.body,
+      state: data.state,
+      user: {
+         login: getLogin(data.user)
+      },
+      submitted_at: new Date(data.submitted_at),
+   };
+}
+
+/**
+ * Takes an object representing a DB row, and returns an instance of this
+ * Review object.
+ */
+Review.getFromDB = function(data) {
+   return new Review({
+      repo: data.repo,
+      id: data.review_id,
+      number: data.number,
+      body: data.body,
+      state: data.state,
+      user: {
+         login: data.user
+      },
+      submitted_at: utils.fromUnixTime(data.date)
+   });
+};
+
+module.exports = Review;

--- a/models/signature.js
+++ b/models/signature.js
@@ -38,8 +38,6 @@ Signature.parseComment = function parseComment(comment, repoFullName, pullNumber
             },
             type: tag.name,
             created_at: comment.created_at,
-            // `active` is unknown until all the signatures have been created
-            // and parsed. See Pull.prototype.updateActiveSignatures()
             active: true,
             comment_id: comment.id
          }));

--- a/models/signature.js
+++ b/models/signature.js
@@ -26,25 +26,16 @@ function Signature(data) {
  * Returns an empty array if the comment did not contain any of our tags.
  */
 Signature.parseComment = function parseComment(comment, repoFullName, pullNumber) {
-   var signatures = [];
-   config.tags.forEach(function(tag) {
-      if (hasTag(comment.body, tag)) {
-         signatures.push(new Signature({
-            repo: repoFullName,
-            number: pullNumber,
-            user: {
-               id:    getUserid(comment.user),
-               login: getLogin(comment.user)
-            },
-            type: tag.name,
-            created_at: comment.created_at,
-            active: true,
-            comment_id: comment.id
-         }));
-      }
-   });
+   const commentData = {
+      repo: repoFullName,
+      number: pullNumber,
+      body: comment.body,
+      user: comment.user,
+      created_at: comment.created_at,
+      id: comment.id
+   }
 
-   return signatures;
+   return parseSignatures(commentData);
 };
 
 /**
@@ -52,26 +43,40 @@ Signature.parseComment = function parseComment(comment, repoFullName, pullNumber
  * Returns an empty array if the comment did not contain any of our tags.
  */
 Signature.parseReview = function parseReview(review, repoFullName, pullNumber) {
-   var signatures = [];
+   const reviewData = {
+      repo: repoFullName,
+      number: pullNumber,
+      body: review.body,
+      user: review.user,
+      created_at: review.submitted_at,
+      id: review.id
+   }
+
+   return parseSignatures(reviewData);
+};
+
+function parseSignatures(data) {
+	let signatures = [];
+
    config.tags.forEach(function(tag) {
-      if (hasTag(review.body, tag)) {
+      if (hasTag(data.body, tag)) {
          signatures.push(new Signature({
-            repo: repoFullName,
-            number: pullNumber,
+            repo: data.repo,
+            number: data.number,
             user: {
-               id:    getUserid(review.user),
-               login: getLogin(review.user)
+               id:    getUserid(data.user),
+               login: getLogin(data.user)
             },
             type: tag.name,
-            created_at: review.submitted_at,
+            created_at: data.created_at,
             active: true,
-            comment_id: review.id
+            comment_id: data.id
          }));
       }
    });
 
    return signatures;
-};
+}
 
 /**
  * Takes an object representing a DB row, and returns an instance of this

--- a/models/signature.js
+++ b/models/signature.js
@@ -50,6 +50,32 @@ Signature.parseComment = function parseComment(comment, repoFullName, pullNumber
 };
 
 /**
+ * Parses a GitHub review and returns an array of Signature objects.
+ * Returns an empty array if the comment did not contain any of our tags.
+ */
+Signature.parseReview = function parseReview(review, repoFullName, pullNumber) {
+   var signatures = [];
+   config.tags.forEach(function(tag) {
+      if (hasTag(review.body, tag)) {
+         signatures.push(new Signature({
+            repo: repoFullName,
+            number: pullNumber,
+            user: {
+               id:    getUserid(review.user),
+               login: getLogin(review.user)
+            },
+            type: tag.name,
+            created_at: review.submitted_at,
+            active: true,
+            comment_id: review.id
+         }));
+      }
+   });
+
+   return signatures;
+};
+
+/**
  * Takes an object representing a DB row, and returns an instance of this
  * Signature object.
  */


### PR DESCRIPTION
This adds a new reviews table, and the various necessary models, getters, setters, etc. to store and retrieve them from the `metrics` DB.

This also adds the necessary logic to parse signatures (e.g. CR, QA, dev_block) out of the review text, in case people use a GitHub review to sign off on a pull.

QA
---
I tested this pretty extensively locally, but it's probably a good idea to make sure that signatures in Comments and Reviews play nicely together. Editing and deleting comments and reviews (I couldn't figure out how to delete a review), etc. works as expected.

Closes #146

CC @evannoronha 