### PR TITLE
Pulldasher: Add support for GitHub Actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "8.11.1"
-  - "10.1.0"
-before_script:
-  - npm install

--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -136,6 +136,8 @@ var HooksController = {
 
             dbUpdated = dbManager.updateComment(comment);
          }
+      } else if (event === 'check_run') {
+         dbUpdated = dbManager.updateCommitCheck(body);
       }
 
       if (dbUpdated) {

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -137,7 +137,7 @@ var dbManager = module.exports = {
       let repo = body.repository.full_name;
       let sha = body.check_run.head_sha;
       let state = utils.mapCheckToStatus(body.check_run.conclusion || body.check_run.status);
-      let desc = utils.mapCheckToStatus(body.check_run.conclusion || body.check_run.status);
+      let desc = state;
       let url = body.check_run.html_url;
       let context = body.check_run.name;
 

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -1,5 +1,6 @@
 var _ = require('underscore'),
     debug = require('./debug')('pulldasher:db-manager'),
+    utils = require('./utils'),
     Promise = require('bluebird'),
     db = require('../lib/db'),
     DBIssue = require('../models/db_issue'),
@@ -130,6 +131,41 @@ var dbManager = module.exports = {
          debug('updateCommitStatus: updated status of Pull #%s in repo %s',
              pullNumber, dbStatus.data.repo);
       });
+   },
+
+   updateCommitCheck: function(body) {
+      let repo = body.repository.full_name;
+      let sha = body.check_run.head_sha;
+      let state = utils.mapCheckToStatus(body.check_run.conclusion || body.check_run.status);
+      let desc = utils.mapCheckToStatus(body.check_run.conclusion || body.check_run.status);
+      let url = body.check_run.html_url;
+      let context = body.check_run.name;
+
+      debug('Calling `updateCommitCheck for commit %s in repo %s and context %s',
+         sha, repo, context);
+      let status = new Status({
+         repo:          repo,
+         sha:           sha,
+         state:         state,
+         description:   desc,
+         target_url:    url,
+         context:       context,
+      });
+
+      var dbStatus = new DBStatus(status);
+      return dbStatus.save()
+         .then(() => this.getPullNumberFromSha(repo, sha))
+         .then(function(pullNumber) {
+            if (pullNumber === null) {
+               debug('updateCommitCheck: commit %s is not the HEAD of any pull, none to refresh in repo %s',
+                  sha, repo);
+               return;
+            }
+
+            queue.markPullAsDirty(repo, pullNumber);
+            debug('updateCommitCheck: updated status of Pull #%s in repo %s',
+               pullNumber, repo);
+         });
    },
 
    /**

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -204,8 +204,8 @@ module.exports = {
          });
 
          let statuses = commitStatuses.map(function(commitStatus) {
-            let state = commitStatus.state || mapCheckToStatus(commitStatus.conclusion || commitStatus.status);
-            let desc = commitStatus.description || mapCheckToStatus(commitStatus.conclusion || commitStatus.status);
+            let state = commitStatus.state || utils.mapCheckToStatus(commitStatus.conclusion || commitStatus.status);
+            let desc = commitStatus.description || utils.mapCheckToStatus(commitStatus.conclusion || commitStatus.status);
             let url = commitStatus.target_url || commitStatus.html_url;
             let context = commitStatus.context || commitStatus.name;
 
@@ -399,24 +399,6 @@ async function getCommitStatuses(repo, ref) {
       .then(res => res.data.check_runs)
       .then(check_runs => check_runs || [])
    return statuses.concat(checks)
-}
-
-/**
- * Statuses and checks have slightly different status names. Let's map the
- * check values to match the status values.
- */
-function mapCheckToStatus(status) {
-   switch (status) {
-      case 'in_progress':
-      case 'queued':
-         return 'pending';
-      case 'success':
-         return 'success';
-      case 'failure':
-         return 'failure';
-      default:
-         return 'error';
-   }
 }
 
 /**

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -204,13 +204,18 @@ module.exports = {
          });
 
          let statuses = commitStatuses.map(function(commitStatus) {
+            let state = commitStatus.state || mapCheckToStatus(commitStatus.conclusion || commitStatus.status);
+            let desc = commitStatus.description || mapCheckToStatus(commitStatus.conclusion || commitStatus.status);
+            let url = commitStatus.target_url || commitStatus.html_url;
+            let context = commitStatus.context || commitStatus.name;
+
             return new Status({
                repo:          repo,
                sha:           githubPull.head.sha,
-               state:         commitStatus.state,
-               description:   commitStatus.description,
-               target_url:    commitStatus.target_url,
-               context:       commitStatus.context,
+               state:         state,
+               description:   desc,
+               target_url:    url,
+               context:       context,
             });
          });
 
@@ -387,9 +392,31 @@ function getCommit(repo, sha) {
 
 function getCommitStatuses(repo, ref) {
    debug("Getting commit status for %s", ref);
-   return githubRest.repos.getCombinedStatusForRef(params({ ref }, repo))
+   let statuses = githubRest.repos.getCombinedStatusForRef(params({ ref }, repo))
       .then(res => res.data.statuses)
       .then(statuses => statuses || [])
+   let checks = githubRest.checks.listForRef(params({ ref }, repo))
+      .then(res => res.data.check_runs)
+      .then(check_runs => check_runs || [])
+   return statuses.concat(checks)
+}
+
+/**
+ * Statuses and checks have slightly different status names. Let's map the
+ * check values to match the status values.
+ */
+function mapCheckToStatus(status) {
+   switch (status) {
+      case 'in_progress':
+      case 'queued':
+         return 'pending';
+      case 'success':
+         return 'success';
+      case 'failure':
+         return 'failure';
+      default:
+         return 'error';
+   }
 }
 
 /**

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -130,6 +130,7 @@ module.exports = {
       var comments = getIssueComments(repo, githubPull.number);
       var headCommit = getCommit(repo, githubPull.head.sha);
       var commitStatuses = getCommitStatuses(repo, githubPull.head.sha);
+      var commitChecks = getCommitChecks(repo, githubPull.head.sha);
       var events = getIssueEvents(repo, githubPull.number);
       // Only so we have the canonical list of labels.
       var ghIssue = module.exports.getIssue(repo, githubPull.number);
@@ -141,6 +142,7 @@ module.exports = {
                           comments,
                           headCommit,
                           commitStatuses,
+                          commitChecks,
                           events,
                           ghIssue,
                           reviews])
@@ -149,9 +151,10 @@ module.exports = {
              comments       = results[1],
              headCommit     = results[2],
              commitStatuses = results[3],
-             events         = results[4],
-             ghIssue        = results[5],
-             reviews        = results[6];
+             commitChecks   = results[4],
+             events         = results[5],
+             ghIssue        = results[6],
+             reviews        = results[7];
 
          // Array of Signature objects.
          var commentSignatures = comments.reduce(function(sigs, comment) {
@@ -204,10 +207,10 @@ module.exports = {
          });
 
          let statuses = commitStatuses.map(function(commitStatus) {
-            let state = commitStatus.state || utils.mapCheckToStatus(commitStatus.conclusion || commitStatus.status);
-            let desc = commitStatus.description || utils.mapCheckToStatus(commitStatus.conclusion || commitStatus.status);
-            let url = commitStatus.target_url || commitStatus.html_url;
-            let context = commitStatus.context || commitStatus.name;
+            let state = commitStatus.state;
+            let desc = commitStatus.description;
+            let url = commitStatus.target_url;
+            let context = commitStatus.context;
 
             return new Status({
                repo:          repo,
@@ -219,10 +222,28 @@ module.exports = {
             });
          });
 
+         let checks = commitChecks.map(function(commitCheck) {
+            let state = utils.mapCheckToStatus(commitCheck.conclusion || commitCheck.status);
+            let desc = utils.mapCheckToStatus(commitCheck.conclusion || commitCheck.status);
+            let url = commitCheck.html_url;
+            let context = commitCheck.name;
+
+            return new Status({
+               repo:          repo,
+               sha:           githubPull.head.sha,
+               state:         state,
+               description:   desc,
+               target_url:    url,
+               context:       context,
+            });
+         });
+
+         let allCommitStatuses = statuses.concat(checks);
+
          // Array of Label objects.
          const labels = getLabelsFromEvents(events, ghIssue);
 
-         const pull = Pull.fromGithubApi(githubPull, signatures, comments, reviews, statuses, labels);
+         const pull = Pull.fromGithubApi(githubPull, signatures, comments, reviews, allCommitStatuses, labels);
          return pull.syncToIssue();
       });
    },
@@ -390,15 +411,18 @@ function getCommit(repo, sha) {
    return githubRest.repos.getCommit(params({ ref: sha }, repo)).then(res => res.data);
 }
 
-async function getCommitStatuses(repo, ref) {
+function getCommitStatuses(repo, ref) {
    debug("Getting commit status for %s", ref);
-   let statuses = await githubRest.repos.getCombinedStatusForRef(params({ ref }, repo))
+   return githubRest.repos.getCombinedStatusForRef(params({ ref }, repo))
       .then(res => res.data.statuses)
       .then(statuses => statuses || [])
-   let checks = await githubRest.checks.listForRef(params({ ref }, repo))
+}
+
+function getCommitChecks(repo, ref) {
+   debug("Getting commit checks for %s", ref);
+   return githubRest.checks.listForRef(params({ ref }, repo))
       .then(res => res.data.check_runs)
       .then(check_runs => check_runs || [])
-   return statuses.concat(checks)
 }
 
 /**

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -224,7 +224,7 @@ module.exports = {
 
          let checks = commitChecks.map(function(commitCheck) {
             let state = utils.mapCheckToStatus(commitCheck.conclusion || commitCheck.status);
-            let desc = utils.mapCheckToStatus(commitCheck.conclusion || commitCheck.status);
+            let desc = state;
             let url = commitCheck.html_url;
             let context = commitCheck.name;
 

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -390,12 +390,12 @@ function getCommit(repo, sha) {
    return githubRest.repos.getCommit(params({ ref: sha }, repo)).then(res => res.data);
 }
 
-function getCommitStatuses(repo, ref) {
+async function getCommitStatuses(repo, ref) {
    debug("Getting commit status for %s", ref);
-   let statuses = githubRest.repos.getCombinedStatusForRef(params({ ref }, repo))
+   let statuses = await githubRest.repos.getCombinedStatusForRef(params({ ref }, repo))
       .then(res => res.data.statuses)
       .then(statuses => statuses || [])
-   let checks = githubRest.checks.listForRef(params({ ref }, repo))
+   let checks = await githubRest.checks.listForRef(params({ ref }, repo))
       .then(res => res.data.check_runs)
       .then(check_runs => check_runs || [])
    return statuses.concat(checks)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,5 +54,23 @@ module.exports = {
       .then(function(repoItems) {
          return _.flatten(repoItems, /* shallow */ true);
       });
+   },
+
+   /**
+    * Statuses and checks have slightly different status names. Let's map the
+    * check values to match the status values.
+    */
+   mapCheckToStatus: function(status) {
+      switch (status) {
+         case 'in_progress':
+         case 'queued':
+            return 'pending';
+         case 'success':
+            return 'success';
+         case 'failure':
+            return 'failure';
+         default:
+            return 'error';
+      }
    }
 };


### PR DESCRIPTION
This adds support for GitHub Actions. Normal GitHub status checks should remain unchanged.

We turned on the check_run webhook on the ifixit org. We now listen for that event and create 
a dbStatus which is entered into the DB the same way that commit statuses are.

The manual refresh works by pinging the github api for a given sha. We had to concatenate both
the statuses and the checks. We then pull off the relevant information and send that to the
`commit_statuses` table.

CC @danielbeardsley @BaseInfinity 

Closes https://github.com/iFixit/pulldasher/issues/227