### PR TITLE
Dockerfile: commit to node 16 for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:16-alpine
 
 RUN mkdir -p /opt/pulldasher
 WORKDIR /opt/pulldasher


### PR DESCRIPTION
Previously, the build broke cause node v17 had a backward incompatible change that broke some crypto thing in a dependency.

![image](https://user-images.githubusercontent.com/26855/148889322-09d7c77d-5a3d-4c1a-82e5-1a3d9df1e319.png)
