### PR TITLE
New UI: add copy branch button

### DIFF
--- a/frontend/src/pull-card/copy-branch.tsx
+++ b/frontend/src/pull-card/copy-branch.tsx
@@ -1,0 +1,27 @@
+import { useClipboard, chakra } from "@chakra-ui/react"
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCopy, faCheck } from '@fortawesome/free-solid-svg-icons'
+
+const CopyBranchIcon = chakra(FontAwesomeIcon, {
+   baseStyle: {
+      marginLeft: "10px",
+      cursor: "pointer",
+      color: "var(--copy-branch)",
+      "&:hover": {
+         color: "var(--copy-branch-hover)",
+      },
+   }
+});
+
+export function CopyBranch({className, value}: {className:string, value:string}) {
+   const {onCopy, hasCopied} = useClipboard(value);
+   return (
+      <CopyBranchIcon
+         title="Copy branch name"
+         size="lg"
+         className={className}
+         onClick={onCopy}
+         icon={hasCopied ? faCheck : faCopy}
+      />
+   );
+}

--- a/frontend/src/pull-card/index.tsx
+++ b/frontend/src/pull-card/index.tsx
@@ -3,6 +3,7 @@ import { CommitStatuses } from './commit-statuses';
 import { Age } from './age';
 import { Flags } from './flags';
 import { Signatures } from './signatures';
+import { CopyBranch } from './copy-branch';
 import { Flex, Box, Link, chakra } from "@chakra-ui/react"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faStar } from '@fortawesome/free-solid-svg-icons'
@@ -14,6 +15,12 @@ const Card = chakra(Flex, {
       borderTop: "1px #ccc solid",
       "&:hover .build_status": {
          opacity: 1
+      },
+      "& .copy": {
+         visibility: "hidden",
+      },
+      "&:hover .copy": {
+         visibility: "visible",
       },
       "& .star": {
          marginRight: "0.5em"
@@ -41,6 +48,10 @@ export function PullCard({pull}: {pull: Pull}) {
                <chakra.span fontWeight="bold">{pull.getRepoName()} #{pull.number}: </chakra.span>
                {pull.title}
             </Link>
+            <CopyBranch
+               value={pull.head.ref}
+               className="copy"
+            />
             <SigsAndFlags wrap="wrap">
                <Signatures
                   pull={pull}

--- a/views/standard/less/themes/day_theme.less
+++ b/views/standard/less/themes/day_theme.less
@@ -163,4 +163,7 @@ body[data-theme="day_theme"] {
     // Refresh on hover
     --refresh-default: darken(@grey, 25%);
     --refresh-hover: darken(@blue, 10%);
+
+    --copy-branch: darken(@grey, 25%);
+    --copy-branch-hover: darken(@blue, 10%);
 }

--- a/views/standard/less/themes/night_theme.less
+++ b/views/standard/less/themes/night_theme.less
@@ -156,6 +156,9 @@ body[data-theme="night_theme"] {
     --refresh-default: darken(@grey, 10%);
     --refresh-hover: @blue;
 
+    --copy-branch: darken(@grey, 25%);
+    --copy-branch-hover: @blue;
+
    i.fa.fa-sun-o:hover {
       color: @yellow !important;
    }


### PR DESCRIPTION
Add a button to copy the branch name of a given pull to the clipboard.

Old UI has this, but you had to hover, then press Ctrl-C. Most of the time it worked, but there was no feedback.

Hovering the pull shows the button:
![image](https://user-images.githubusercontent.com/26855/159219575-413498f0-1284-4e12-a913-523a7e34eeb2.png)

Button hovered:
![image](https://user-images.githubusercontent.com/26855/159219669-ffd67b79-018c-4dbf-8bf6-82fcc28c7390.png)

After Successful Copy:
![image](https://user-images.githubusercontent.com/26855/159219801-73ad7672-f715-4df8-b3d3-4627ae957e96.png)
