### PR TITLE
CR/QA Columns: Exclude dev blocked pulls

### DIFF
--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -11,8 +11,8 @@ export const Pulldasher: React.FC = function() {
    const pullsDeployBlocked = pulls.filter(pull => pull.isDeployBlocked());
    const pullsReady = pulls.filter(pull => pull.isReady());
    const pullsDevBlocked = pulls.filter(pull => pull.getDevBlock());
-   const pullsNeedingCR = pulls.filter(pull => !pull.isCrDone());
-   const pullsNeedingQA = pulls.filter(pull => !pull.isQaDone());
+   const pullsNeedingCR = pulls.filter(pull => !pull.isCrDone() && !pull.getDevBlock());
+   const pullsNeedingQA = pulls.filter(pull => !pull.isQaDone() && !pull.getDevBlock());
    const leadersCR = getLeaders(pulls, (pull) => pull.cr_signatures.current);
    const leadersQA = getLeaders(pulls, (pull) => pull.qa_signatures.current);
    return (<>


### PR DESCRIPTION
The old UI excludes these cause it effectively means "contents may
change, don't CR/QA just yet". So we like to keep them off of dev's
radars.

