### PR TITLE
Backend: load all open pulls from the DB on start

### DIFF
--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -377,19 +377,19 @@ var dbManager = module.exports = {
    },
 
    /**
-    * Returns a promise which resolves to an array of Pull objects for the
-    * given pull numbers built from data stored in the database.
+    * Returns a promise which resolves to an array of Pull objects for all open
+    * pulls from the DB
     */
-   getOpenPulls: function(repo) {
+   getOpenPulls: function() {
       var self = this;
-      debug('Calling getOpenPulls for %s', repo);
-      var q_select = 'SELECT number FROM pulls WHERE state = ? AND repo = ?';
+      debug('Calling getOpenPulls');
+      var q_select = 'SELECT repo, number FROM pulls WHERE state = ?';
 
-      return db.query(q_select, ['open', repo]).then(function(rows) {
+      return db.query(q_select, ['open']).then(function(rows) {
          debug('Found %s open pulls in the DB', rows.length);
          if (rows.length === 0) { return []; }
          var pulls = _.map(rows, function(row) {
-            return self.getPull(repo, row.number);
+            return self.getPull(row.repo, row.number);
          });
          return Promise.all(pulls);
       }).then(filterNulls);


### PR DESCRIPTION
Previously, we only loaded pulls that were in our *repo* array from the config.

This meant that after a restart, some pulls may disappear.
We may receive webhooks for repos not in that array,
show the pulls for a while (cause they are in memory), then they
disappear on restart cause they don't get loaded from the DB.

The repo list is now only used on start when we refresh all pulls from
the API (need to know which repos to ask about).

Future Work
====
We may want to support `{orgname}/*` in the repo-list or something.