### PR TITLE
Frontend: Hide Closed Pulls

### DIFF
--- a/frontend/dummy-pulls.json
+++ b/frontend/dummy-pulls.json
@@ -7672,8 +7672,8 @@
   {
     "repo": "iFixit/server-templates",
     "number": 2886,
-    "state": "open",
-    "title": "Akeneo: Polish RDS and drop services",
+    "state": "closed",
+    "title": "Akeneo: This pull is closed and should be hidden",
     "body": "pull request dummy body",
     "created_at": "2020-12-23T01:36:52.000Z",
     "updated_at": "2020-12-23T01:37:27.000Z",

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -13,6 +13,10 @@ export class Pull extends PullData {
       this.qa_signatures = computeSignatures(data.status.allQA);
    }
 
+   isOpen(): boolean {
+      return this.state == 'open';
+   }
+
    getUrl(): string {
       return 'https://github.com/' + this.repo + '/pull/' + this.number;
    }

--- a/frontend/src/pulldasher/filtered-pulls-state.ts
+++ b/frontend/src/pulldasher/filtered-pulls-state.ts
@@ -7,13 +7,17 @@ export type FilterFunctionSetter = (filterName:string, filter:FilterFunction|nul
 type Filters = Record<string, FilterFunction>;
 type ReturnType = [Pull[], FilterFunctionSetter];
 
+const defaultFilters = {
+   'default': (pull: Pull) => pull.isOpen()
+}
+
 /**
  * Wrapper around an array of pulls that allows multiple filters to be
  * specified.
  * setFilter(name, func) will *remove* the filter if func is null
  */
 export function useFilteredPullsState(pulls: Pull[]): ReturnType {
-   const [filters, setFilter] = useState<Filters>({});
+   const [filters, setFilter] = useState<Filters>(defaultFilters);
    return [
       filterPulls(pulls, filters),
       (filterName:string, filter:FilterFunction|null) => {


### PR DESCRIPTION
The backend won't send us closed pulls in the initial list, but we
hadn't been hiding pulls that *become* closed after the page has been
loaded. This meant that a merged pull would jut sit around in the ready
column, even after it's been closed.

The old UI did this, it was just overlooked.