### PR TITLE
Ready Column: exclude pulls with no CI

### DIFF
--- a/frontend/dummy-pulls.json
+++ b/frontend/dummy-pulls.json
@@ -1907,7 +1907,7 @@
     "repo": "iFixit/ifixit",
     "number": 35249,
     "state": "open",
-    "title": "Algolia Search Keywords: Index them",
+    "title": "Ready pull that has no CI and should be in Deploy Block column",
     "body": "pull request dummy body",
     "created_at": "2020-11-30T20:28:50.000Z",
     "updated_at": "2020-12-01T15:50:31.000Z",
@@ -1938,7 +1938,22 @@
     "status": {
       "qa_req": 1,
       "cr_req": 2,
-      "QA": [],
+      "QA": [
+        {
+          "data": {
+            "repo": "iFixit/ifixit",
+            "number": 35258,
+            "user": {
+              "id": 58952979,
+              "login": "batbattur"
+            },
+            "type": "QA",
+            "created_at": "2020-12-01T01:02:51.000Z",
+            "active": 1,
+            "comment_id": 736148899
+          }
+        }
+      ],
       "CR": [
         {
           "data": {
@@ -1969,7 +1984,22 @@
           }
         }
       ],
-      "allQA": [],
+      "allQA": [
+        {
+          "data": {
+            "repo": "iFixit/ifixit",
+            "number": 35258,
+            "user": {
+              "id": 58952979,
+              "login": "batbattur"
+            },
+            "type": "QA",
+            "created_at": "2020-12-01T01:02:51.000Z",
+            "active": 1,
+            "comment_id": 736148899
+          }
+        }
+      ],
       "allCR": [
         {
           "data": {
@@ -2016,46 +2046,10 @@
       ],
       "dev_block": [],
       "deploy_block": [],
-      "commit_statuses": [
-        {
-          "data": {
-            "sha": "86b6d9cd5fdb231a6e2c5249aaa745b7428a981c",
-            "target_url": "https://wwww.example.com",
-            "description": "Build success",
-            "state": "success",
-            "context": "jest"
-          }
-        },
-        {
-          "data": {
-            "sha": "86b6d9cd5fdb231a6e2c5249aaa745b7428a981c",
-            "target_url": "https://wwww.example.com",
-            "description": "Build success",
-            "state": "success",
-            "context": "phpunit"
-          }
-        },
-        {
-          "data": {
-            "sha": "86b6d9cd5fdb231a6e2c5249aaa745b7428a981c",
-            "target_url": "https://wwww.example.com",
-            "description": "Build success",
-            "state": "success",
-            "context": "psalm"
-          }
-        }
-      ],
+      "commit_statuses": [],
       "ready": false
     },
-    "labels": [
-      {
-        "title": "QAing",
-        "number": 35249,
-        "repo": "iFixit/ifixit",
-        "user": "k0rvusk0r4x",
-        "created_at": "2020-12-01T15:50:31.000Z"
-      }
-    ]
+    "labels": []
   },
   {
     "repo": "iFixit/ifixit",

--- a/frontend/src/pull-card/flags.tsx
+++ b/frontend/src/pull-card/flags.tsx
@@ -57,6 +57,7 @@ function PullFlag({variant, title, href, icon}: PullFlagProps) {
    <Link
       sx={styles}
       href={href}
+      title={title}
       className="pull-flag">
       <FontAwesomeIcon icon={icon}/>
    </Link> :

--- a/frontend/src/pull-card/flags.tsx
+++ b/frontend/src/pull-card/flags.tsx
@@ -9,6 +9,7 @@ import { faWarning, faMinusCircle, faEye, faEyeSlash, faSnowflake } from '@forta
 export const Flags = memo(
 function Flags({pull}: {pull: Pull}) {
    const devBlock = pull.getDevBlock();
+   const readyButNoCI = pull.isReady() && !pull.isCiRequired();
    const deployBlock = pull.getDeployBlock();
    const QAing = pull.getLabel("QAing");
    const externalBlock = pull.getLabel("external_block");
@@ -18,6 +19,11 @@ function Flags({pull}: {pull: Pull}) {
          variant="deployBlock"
          title={actionMessage('Deploy blocked', deployBlock.data.created_at, deployBlock.data.user.login)}
          href={pull.linkToSignature(deployBlock)}
+         icon={faWarning}
+      />}
+      {readyButNoCI && <PullFlag
+         variant="deployBlock"
+         title={"No CI, deploy carefully"}
          icon={faWarning}
       />}
       {devBlock && <PullFlag

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -71,16 +71,23 @@ export class Pull extends PullData {
       });
    }
 
+   // Returns true if this pull doesn't have and doesn't need any CI statuses
+   isCiNotNeeded(): boolean {
+      return this.getRequiredBuildStatuses().length === 0 &&
+         this.buildStatuses().length === 0;
+   }
+
    isReady(): boolean {
       return this.hasMetDeployRequirements()
          && !this.getDevBlock()
-         && !this.getDeployBlock();
+         && !this.getDeployBlock()
+         && !this.isCiNotNeeded();
    }
 
    isDeployBlocked(): boolean {
       return this.hasMetDeployRequirements()
          && !this.getDevBlock()
-         && !!this.getDeployBlock();
+         && (!!this.getDeployBlock() || this.isCiNotNeeded());
    }
 
    hasMetDeployRequirements(): boolean {

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -71,23 +71,25 @@ export class Pull extends PullData {
       });
    }
 
-   // Returns true if this pull doesn't have and doesn't need any CI statuses
-   isCiNotNeeded(): boolean {
-      return this.getRequiredBuildStatuses().length === 0 &&
-         this.buildStatuses().length === 0;
+   /**
+    * Returns true if there are required CI statues OR if there are *any* CI
+    * statuses
+    */
+   isCiRequired(): boolean {
+      return this.getRequiredBuildStatuses().length > 0 ||
+         this.buildStatuses().length > 0;
    }
 
    isReady(): boolean {
       return this.hasMetDeployRequirements()
          && !this.getDevBlock()
-         && !this.getDeployBlock()
-         && !this.isCiNotNeeded();
+         && !this.getDeployBlock();
    }
 
    isDeployBlocked(): boolean {
       return this.hasMetDeployRequirements()
          && !this.getDevBlock()
-         && (!!this.getDeployBlock() || this.isCiNotNeeded());
+         && (!!this.getDeployBlock() || !this.isCiRequired());
    }
 
    hasMetDeployRequirements(): boolean {

--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -8,7 +8,7 @@ export const Pulldasher: React.FC = function() {
    const pulls = useAllPulls();
    const pullsCIBlocked = pulls.filter(pull => pull.isCiBlocked());
    const pullsDeployBlocked = pulls.filter(pull => pull.isDeployBlocked());
-   const pullsReady = pulls.filter(pull => pull.isReady());
+   const pullsReady = pulls.filter(pull => pull.isReady() && pull.isCiRequired());
    const pullsDevBlocked = pulls.filter(pull => pull.getDevBlock());
    const pullsNeedingCR = pulls.filter(pull => !pull.isCrDone() && !pull.getDevBlock());
    const pullsNeedingQA = pulls.filter(pull => !pull.isQaDone() && !pull.getDevBlock());


### PR DESCRIPTION
If a pull has no CI statuses and no required statuses, then it should be
in the deploy block column because likely it'll need some manual
intervention for deployment.

Closes #272