### PR TITLE
Navbar: Add UI for Repo Filter

### DIFF
--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -1,3 +1,4 @@
+import { RepoMenu } from './repo-menu';
 import { usePulls, useSetFilter } from './pulldasher/pulls-context';
 import { Pull } from './pull';
 import { useColorMode, Button, HStack, Center, Flex, Box, BoxProps, Input } from "@chakra-ui/react";
@@ -45,6 +46,7 @@ export function Navbar(props: BoxProps) {
                   onClick={toggleColorMode}>
                   <FontAwesomeIcon icon={faMoon}/>
                </Button>
+               <RepoMenu/>
             </HStack>
             <Box alignSelf="center" fontSize={20}>
                <span style={{fontVariantCaps: "small-caps"}}>Pulldasher</span>

--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -7,6 +7,9 @@ import { useBoolUrlState } from "./use-url-state";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSnowflake, faMoon } from '@fortawesome/free-solid-svg-icons'
 
+// Default width of the left and right sections of the nav bar
+const sideWidth = "220px";
+
 export function Navbar(props: BoxProps) {
    const pulls: Set<Pull> = usePulls();
    const setPullFilter = useSetFilter();
@@ -27,8 +30,8 @@ export function Navbar(props: BoxProps) {
 
    return (
       <Center py={2} bgColor="var(--header-background)" color="var(--brand-color)" {...props}>
-         <Flex px="var(--body-gutter)" maxW="100%" w="var(--body-max-width)" justify="space-between">
-            <HStack alignSelf="center" w="200px" spacing="2">
+         <Flex px="var(--body-gutter)" maxW="100%" w="var(--body-max-width)" gap="var(--body-gutter)" justify="space-between">
+            <HStack alignSelf="center" flexGrow="1" flexBasis={sideWidth} spacing="2">
                <span>{pulls.size} open</span>
                <Button
                   size="sm"
@@ -48,15 +51,15 @@ export function Navbar(props: BoxProps) {
                </Button>
                <RepoMenu/>
             </HStack>
-            <Box alignSelf="center" fontSize={20}>
+            <Box alignSelf="center" fontSize={20} flexShrink="0">
                <span style={{fontVariantCaps: "small-caps"}}>Pulldasher</span>
                &nbsp;&nbsp;-&nbsp;&nbsp;
                <span style={{fontSize: "12px"}}>
                   back to <a href="/">old ui</a>
                </span>
             </Box>
-            <Box w="200px" textAlign="right">
-               <Input w={150} onChange={updateSearchFilter} placeholder="Search"/>
+            <Box flexBasis={sideWidth} flexGrow="1" flexShrink="1" textAlign="right">
+               <Input w="100%" maxWidth={sideWidth} onChange={updateSearchFilter} placeholder="Search"/>
             </Box>
          </Flex>
       </Center>

--- a/frontend/src/repo-menu.tsx
+++ b/frontend/src/repo-menu.tsx
@@ -1,7 +1,7 @@
 import { useAllPulls, useSetFilter } from './pulldasher/pulls-context';
 import { useArrayUrlState } from './use-url-state';
 import { Pull } from './pull';
-import { Button, Menu, MenuButton, MenuList, MenuDivider, MenuOptionGroup, MenuItemOption } from "@chakra-ui/react";
+import { useConst, Button, Menu, MenuButton, MenuList, MenuDivider, MenuOptionGroup, MenuItemOption } from "@chakra-ui/react";
 import { useEffect, useCallback, useMemo } from 'react'
 
 type RepoCounts = Map<string, number>;
@@ -12,9 +12,16 @@ export function RepoMenu() {
    const [selectedRepos, setSelectedRepos] = useArrayUrlState('repo', []);
    // Nothing selected == show everything, otherwise, it'd be empty
    const showAll = selectedRepos.length === 0;
+   // List from url may contain repos we have no pulls for
+   const urlRepos = useConst(() => new Set(selectedRepos));
    const setPullFilter = useSetFilter();
 
-   const allRepos = useMemo(() => Array.from(new Set(pulls.map((pull) => pull.getRepoName()))), [pulls]);
+   // May include repos frmo the url for which there are no pulls
+   const allRepos = useMemo(() => {
+      // All repos of open pulls
+      const pullRepos = new Set(pulls.map((pull) => pull.getRepoName()));
+      return [...new Set([...pullRepos, ...urlRepos])]
+   }, [pulls]);
    const repoToPullCount = useMemo(() => getRepoToPullCount(pulls), [pulls]);
 
    const onSelectedChange = useCallback((newSelectedRepos: string | string[]) => {

--- a/frontend/src/repo-menu.tsx
+++ b/frontend/src/repo-menu.tsx
@@ -14,7 +14,6 @@ export function RepoMenu() {
    const setPullFilter = useSetFilter();
 
    const allRepos = useMemo(() => Array.from(new Set(pulls.map((pull) => pull.getRepoName()))), [pulls]);
-   const selectedReposSet = useMemo(() => new Set(selectedRepos), [selectedRepos]);
    const repoToPullCount = useMemo(() => getRepoToPullCount(pulls), [pulls]);
 
    const onSelectedChange = useCallback((newSelectedRepos: string | string[]) => {
@@ -51,8 +50,7 @@ export function RepoMenu() {
           {allRepos.map((repo) =>
              <MenuItemOption
                 key={repo}
-                value={repo}
-                isChecked={showAll || selectedReposSet.has(repo)}>
+                value={repo}>
                 {repo} ({repoToPullCount.get(repo) || 0})
              </MenuItemOption>
           )}

--- a/frontend/src/repo-menu.tsx
+++ b/frontend/src/repo-menu.tsx
@@ -1,7 +1,10 @@
 import { useAllPulls, useSetFilter } from './pulldasher/pulls-context';
 import { useArrayUrlState } from './use-url-state';
+import { Pull } from './pull';
 import { Button, Menu, MenuButton, MenuList, MenuOptionGroup, MenuItemOption } from "@chakra-ui/react";
 import { useEffect, useCallback, useMemo } from 'react'
+
+type RepoCounts = Map<string, number>;
 
 export function RepoMenu() {
    const pulls = useAllPulls();
@@ -12,6 +15,7 @@ export function RepoMenu() {
 
    const allRepos = useMemo(() => Array.from(new Set(pulls.map((pull) => pull.getRepoName()))), [pulls]);
    const selectedReposSet = useMemo(() => new Set(selectedRepos), [selectedRepos]);
+   const repoToPullCount = useMemo(() => getRepoToPullCount(pulls), [pulls]);
 
    const onSelectedChange = useCallback((newSelectedRepos: string | string[]) => {
       newSelectedRepos = Array.from(newSelectedRepos);
@@ -49,11 +53,18 @@ export function RepoMenu() {
                 key={repo}
                 value={repo}
                 isChecked={showAll || selectedReposSet.has(repo)}>
-                {repo}
+                {repo} ({repoToPullCount.get(repo) || 0})
              </MenuItemOption>
           )}
        </MenuOptionGroup>
      </MenuList>
    </Menu>
    );
+}
+
+function getRepoToPullCount(pulls: Pull[]): RepoCounts {
+   return pulls.reduce((counts, pull) => {
+      counts.set(pull.getRepoName(), (counts.get(pull.getRepoName()) || 0) + 1);
+      return counts;
+   }, new Map() as RepoCounts);
 }

--- a/frontend/src/repo-menu.tsx
+++ b/frontend/src/repo-menu.tsx
@@ -1,7 +1,7 @@
 import { useAllPulls, useSetFilter } from './pulldasher/pulls-context';
 import { useArrayUrlState } from './use-url-state';
 import { Pull } from './pull';
-import { Button, Menu, MenuButton, MenuList, MenuOptionGroup, MenuItemOption } from "@chakra-ui/react";
+import { Button, Menu, MenuButton, MenuList, MenuDivider, MenuOptionGroup, MenuItemOption } from "@chakra-ui/react";
 import { useEffect, useCallback, useMemo } from 'react'
 
 type RepoCounts = Map<string, number>;
@@ -18,11 +18,6 @@ export function RepoMenu() {
 
    const onSelectedChange = useCallback((newSelectedRepos: string | string[]) => {
       newSelectedRepos = Array.from(newSelectedRepos);
-      // If they've selected *all* the repos, then let's reset it to the
-      // default (empty array == show all repos)
-      if (newSelectedRepos.length == allRepos.length) {
-         newSelectedRepos = [];
-      }
 
       // Update the url
       setSelectedRepos(newSelectedRepos);
@@ -32,7 +27,7 @@ export function RepoMenu() {
       setPullFilter('repo', selectedReposSet.size === 0 ? null : (pull) =>
          selectedReposSet.has(pull.getRepoName())
       );
-   }, [setPullFilter, setSelectedRepos, allRepos]);
+   }, [setPullFilter, setSelectedRepos]);
 
    // Load initial state from url just once
    useEffect(() => onSelectedChange(selectedRepos), []);
@@ -55,6 +50,13 @@ export function RepoMenu() {
              </MenuItemOption>
           )}
        </MenuOptionGroup>
+       <MenuDivider/>
+       <MenuItemOption
+          key="Show All"
+          onClick={() => onSelectedChange([])}
+          isChecked={showAll}>
+          Show All
+       </MenuItemOption>
      </MenuList>
    </Menu>
    );

--- a/frontend/src/repo-menu.tsx
+++ b/frontend/src/repo-menu.tsx
@@ -1,0 +1,59 @@
+import { useAllPulls, useSetFilter } from './pulldasher/pulls-context';
+import { useArrayUrlState } from './use-url-state';
+import { Button, Menu, MenuButton, MenuList, MenuOptionGroup, MenuItemOption } from "@chakra-ui/react";
+import { useEffect, useCallback, useMemo } from 'react'
+
+export function RepoMenu() {
+   const pulls = useAllPulls();
+   const [selectedRepos, setSelectedRepos] = useArrayUrlState('repo', []);
+   // Nothing selected == show everything, otherwise, it'd be empty
+   const showAll = selectedRepos.length === 0;
+   const setPullFilter = useSetFilter();
+
+   const allRepos = useMemo(() => Array.from(new Set(pulls.map((pull) => pull.getRepoName()))), [pulls]);
+   const selectedReposSet = useMemo(() => new Set(selectedRepos), [selectedRepos]);
+
+   const onSelectedChange = useCallback((newSelectedRepos: string | string[]) => {
+      newSelectedRepos = Array.from(newSelectedRepos);
+      // If they've selected *all* the repos, then let's reset it to the
+      // default (empty array == show all repos)
+      if (newSelectedRepos.length == allRepos.length) {
+         newSelectedRepos = [];
+      }
+
+      // Update the url
+      setSelectedRepos(newSelectedRepos);
+
+      // Update the pull filter
+      const selectedReposSet = new Set(newSelectedRepos);
+      setPullFilter('repo', selectedReposSet.size === 0 ? null : (pull) =>
+         selectedReposSet.has(pull.getRepoName())
+      );
+   }, [setPullFilter, setSelectedRepos, allRepos]);
+
+   // Load initial state from url just once
+   useEffect(() => onSelectedChange(selectedRepos), []);
+
+   return (
+   <Menu closeOnSelect={false}>
+     <MenuButton as={Button} colorScheme='blue' size="sm" variant="outline">
+       Repo
+     </MenuButton>
+     <MenuList minWidth='240px'>
+        <MenuOptionGroup
+           type='checkbox'
+           value={showAll ? allRepos : selectedRepos}
+           onChange={onSelectedChange}>
+          {allRepos.map((repo) =>
+             <MenuItemOption
+                key={repo}
+                value={repo}
+                isChecked={showAll || selectedReposSet.has(repo)}>
+                {repo}
+             </MenuItemOption>
+          )}
+       </MenuOptionGroup>
+     </MenuList>
+   </Menu>
+   );
+}

--- a/frontend/src/repo-menu.tsx
+++ b/frontend/src/repo-menu.tsx
@@ -8,6 +8,7 @@ type RepoCounts = Map<string, number>;
 
 export function RepoMenu() {
    const pulls = useAllPulls();
+   // Default is empty array that implies show all pulls (no filtering)
    const [selectedRepos, setSelectedRepos] = useArrayUrlState('repo', []);
    // Nothing selected == show everything, otherwise, it'd be empty
    const showAll = selectedRepos.length === 0;
@@ -17,6 +18,8 @@ export function RepoMenu() {
    const repoToPullCount = useMemo(() => getRepoToPullCount(pulls), [pulls]);
 
    const onSelectedChange = useCallback((newSelectedRepos: string | string[]) => {
+      // Make typescript happy cause it thinks newSelectedRepos can be a single
+      // string
       newSelectedRepos = Array.from(newSelectedRepos);
 
       // Update the url

--- a/frontend/src/use-url-state.ts
+++ b/frontend/src/use-url-state.ts
@@ -18,18 +18,15 @@ type HistoryState = Record<string, string>;
  * paramName is expected not to change over the life of the component.
  */
 export function useUrlState(paramName: string, paramDefault: string): useUrlStateReturn  {
-   const [state, setState] = useState(paramDefault);
-
-   // Load state from url, only once per component
-   useEffect(() => {
-      const unsubscribe = watchForPopstate(paramName, setState, paramDefault);
+   const [state, setState] = useState((): string =>  {
       const url = new URL(window.location.href);
       const urlState = url.searchParams.get(paramName);
-      if (urlState === null || urlState === state) {
-         return;
-      }
-      setState(urlState);
-      return unsubscribe;
+      return urlState === null ? paramDefault : urlState;
+   });
+
+   // Watch for url state changes (back button) only once per component.
+   useEffect(() => {
+      return watchForPopstate(paramName, setState, paramDefault);
    }, []);
 
    // Wrap setState so it pushes history and transforms the url

--- a/frontend/src/use-url-state.ts
+++ b/frontend/src/use-url-state.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 
 type state = string|null;
 type stateSetter = (state: state) => void;
@@ -82,4 +82,21 @@ export function useBoolUrlState(paramName: string, paramDefault: boolean): [bool
    }, []);
 
    return [state === '1', setBoolState];
+}
+
+/**
+ * Just like useUrlState(), but typed for storing an array of strings
+ */
+export function useArrayUrlState(paramName: string, paramDefault: string[]): [string[], (state: string[]) => void] {
+   const [state, setState] = useUrlState(paramName, paramDefault.join(','));
+
+   const setArrayState = useCallback((newState: string[]) => {
+      setState(newState.join(','));
+   }, [setState]);
+
+   // useMemo() is here so that downstream callers can depend on the array
+   // staying the same referentially if the state hasn't changed.
+   const valueArray = useMemo(() => state ? state.split(',') : [], [state]);
+
+   return [valueArray, setArrayState];
 }


### PR DESCRIPTION
Add a UI to easily show / hide pulls from individual repos.

Meets all the requirements from the issue:

* UI component 
   * multi-select list of repos
   * Selecting *none* of the options reset's to selecting all
   * updates immediately
   * populates list from the open pulls
   * Show the pull count next to each repo name
* Repos
   * list is parsed from the url
   * url is updated when changing the UI component
   * allow repos that don't have pulls to remain in the list if they are parsed from the URL

Closes #268 