### PR TITLE
QA Column: exclude pulls failing CI

### DIFF
--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -11,7 +11,7 @@ export const Pulldasher: React.FC = function() {
    const pullsReady = pulls.filter(pull => pull.isReady() && pull.isCiRequired());
    const pullsDevBlocked = pulls.filter(pull => pull.getDevBlock());
    const pullsNeedingCR = pulls.filter(pull => !pull.isCrDone() && !pull.getDevBlock());
-   const pullsNeedingQA = pulls.filter(pull => !pull.isQaDone() && !pull.getDevBlock());
+   const pullsNeedingQA = pulls.filter(pull => !pull.isQaDone() && !pull.getDevBlock() && pull.hasPassedCI());
    const leadersCR = getLeaders(pulls, (pull) => pull.cr_signatures.current);
    const leadersQA = getLeaders(pulls, (pull) => pull.qa_signatures.current);
    return (<>


### PR DESCRIPTION
Generally, if a pull is failing CI, we'll need to do more work on it
and QA should spend there energy elsewhere.

So, we'll hide pulls that fail CI from the QA Column.

Closes #282 