### PR TITLE
QA column: Use custom sorting order

### DIFF
--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -1,6 +1,7 @@
 import { useAllPulls } from './pulls-context';
 import { Navbar } from '../navbar';
 import { Column } from '../column';
+import { QACompare } from './sort';
 import { LeaderList, getLeaders } from '../leader-list';
 import { Box, SimpleGrid, VStack } from "@chakra-ui/react"
 
@@ -41,7 +42,7 @@ export const Pulldasher: React.FC = function() {
                   <Column id="cr" title="CR" pulls={pullsNeedingCR}/>
                </Box>
                <Box>
-                  <Column id="qa" title="QA" pulls={pullsNeedingQA}/>
+                  <Column id="qa" title="QA" pulls={pullsNeedingQA.sort(QACompare)}/>
                </Box>
             </SimpleGrid>
          </VStack>

--- a/frontend/src/pulldasher/pulls-context.tsx
+++ b/frontend/src/pulldasher/pulls-context.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext } from 'react';
 import { useFilteredPullsState, FilterFunction, FilterFunctionSetter } from './filtered-pulls-state';
 import { usePullsState } from './pulls-state';
 import { Pull } from '../pull';
-import { getUser } from "../page-context";
+import { defaultCompare } from "./sort";
 
 interface PullContextProps {
    // Array of all pulls
@@ -37,7 +37,7 @@ export function useSetFilter(): FilterFunctionSetter {
 export const PullsProvider = function({children}: {children: React.ReactNode}) {
    const unfilteredPulls = usePullsState();
    const [filteredPulls, setFilter] = useFilteredPullsState(unfilteredPulls);
-   const sortedPulls = unfilteredPulls.sort(defaultSort);
+   const sortedPulls = unfilteredPulls.sort(defaultCompare);
    const contextValue = {
       pulls: new Set(filteredPulls),
       allPulls: sortedPulls,
@@ -46,19 +46,4 @@ export const PullsProvider = function({children}: {children: React.ReactNode}) {
    return (<PullsContext.Provider value={contextValue}>
       {children}
    </PullsContext.Provider>);
-}
-
-function defaultSort(a: Pull, b: Pull): number {
-   return (
-    // My pulls above pulls that aren't mine
-    compareBool(a.isMine(), b.isMine()) ||
-    // Pulls I have to CR/QA above those I don't
-    compareBool(a.hasOutdatedSig(getUser()), b.hasOutdatedSig(getUser())) ||
-    // Pulls I haven't touched vs those I have already CRed
-    compareBool(!a.hasCurrentSig(getUser()), !b.hasCurrentSig(getUser()))
-   );
-}
-
-function compareBool(a: boolean, b: boolean): number {
-   return +b - +a;
 }

--- a/frontend/src/pulldasher/sort.ts
+++ b/frontend/src/pulldasher/sort.ts
@@ -29,7 +29,7 @@ export function QACompare(a: Pull, b: Pull): number {
 
 function isQAingByMe(pull: Pull): boolean {
    const label = pull.getLabel('QAing');
-   return !!(label && label.user == getUser());
+   return !!(label?.user == getUser());
 }
 
 function compareBool(a: boolean, b: boolean): number {

--- a/frontend/src/pulldasher/sort.ts
+++ b/frontend/src/pulldasher/sort.ts
@@ -12,6 +12,26 @@ export function defaultCompare(a: Pull, b: Pull): number {
    );
 }
 
+export function QACompare(a: Pull, b: Pull): number {
+   return (
+      // Pulls I'm QAing above those I'm not
+      compareBool(isQAingByMe(a), isQAingByMe(b)) ||
+      // Pulls with no external_block above those with external_block
+      compareBool(!a.getLabel('external_block'), !b.getLabel('external_block')) ||
+      // Pulls with no QAing label above those with QAing
+      compareBool(!a.getLabel('QAing'), !b.getLabel('QAing')) ||
+      // Pulls with CR completed above those that need more
+      compareBool(a.isCrDone(), b.isCrDone()) ||
+      // Older pulls before younger pulls
+      a.created_at.localeCompare(b.created_at)
+   );
+}
+
+function isQAingByMe(pull: Pull): boolean {
+   const label = pull.getLabel('QAing');
+   return !!(label && label.user == getUser());
+}
+
 function compareBool(a: boolean, b: boolean): number {
    return +b - +a;
 }

--- a/frontend/src/pulldasher/sort.ts
+++ b/frontend/src/pulldasher/sort.ts
@@ -1,0 +1,17 @@
+import { Pull } from '../pull';
+import { getUser } from "../page-context";
+
+export function defaultCompare(a: Pull, b: Pull): number {
+   return (
+    // My pulls above pulls that aren't mine
+    compareBool(a.isMine(), b.isMine()) ||
+    // Pulls I have to CR/QA above those I don't
+    compareBool(a.hasOutdatedSig(getUser()), b.hasOutdatedSig(getUser())) ||
+    // Pulls I haven't touched vs those I have already CRed
+    compareBool(!a.hasCurrentSig(getUser()), !b.hasCurrentSig(getUser()))
+   );
+}
+
+function compareBool(a: boolean, b: boolean): number {
+   return +b - +a;
+}

--- a/frontend/src/pulldasher/sort.ts
+++ b/frontend/src/pulldasher/sort.ts
@@ -29,7 +29,7 @@ export function QACompare(a: Pull, b: Pull): number {
 
 function isQAingByMe(pull: Pull): boolean {
    const label = pull.getLabel('QAing');
-   return !!(label?.user == getUser());
+   return label?.user == getUser();
 }
 
 function compareBool(a: boolean, b: boolean): number {


### PR DESCRIPTION
As specified in the issue, the order is broken down like this:

* QAing (by current user)
* Everything else
  * No external Block
    * Not QAing
      * Pulls with completed CR
        * Sort by oldest first 
      * Pulls needing more CR
        * Sort by oldest first 
    * QAing
  * External Block

Closes #280