### PR TITLE
Required Statuses: include "missing" CI bubble

### DIFF
--- a/frontend/src/pull-card/commit-statuses.tsx
+++ b/frontend/src/pull-card/commit-statuses.tsx
@@ -42,7 +42,7 @@ export const CommitStatuses = memo(
 function CommitStatuses({pull}: {pull: Pull}) {
    return (
    <StatusContainer className="build_status_container">
-      {pull.buildStatuses().map((status) =>
+      {pull.buildStatusesWithRequired().map((status) =>
          <Status
             status={status}
             key={status.data.context}

--- a/frontend/test/named-pulls.ts
+++ b/frontend/test/named-pulls.ts
@@ -151,6 +151,31 @@ export const FewStatuses = <PullData[]> [
    }),
 ];
 
+const repoSpec = {name: 'some/repo', requiredStatuses: ['unit-tests']};
+export const RequiredStatuses = <PullData[]> [
+   pullData({
+      repoSpec,
+      title: "Required 'unit-tests' status with it being a failure",
+      status: {
+         commit_statuses: [status("failure", null, 'unit-tests')]
+      },
+   }),
+   pullData({
+      repoSpec,
+      title: "Required 'unit-tests' status with a second non-required status",
+      status: {
+         commit_statuses: [status("success")]
+      },
+   }),
+   pullData({
+      repoSpec,
+      title: "Required 'unit-tests' status with no actual statuses",
+      status: {
+         commit_statuses: []
+      },
+   }),
+];
+
 export const ManyStatuses = <PullData[]> [
    pullData({
       title: "Three commit statuses",

--- a/frontend/test/pull-card-demo.tsx
+++ b/frontend/test/pull-card-demo.tsx
@@ -8,6 +8,7 @@ import {
    FulfilledRequirements,
    Signatures,
    FewStatuses,
+   RequiredStatuses,
    ManyStatuses,
    Blocked,
    Milestones,
@@ -31,6 +32,7 @@ function PullCardDemo() {
          <Row title="Fulfilled Requirements" pullDatas={FulfilledRequirements}/>
          <Row title="Signatures in Different states" pullDatas={Signatures}/>
          <Row title="Few Commit Statuses" pullDatas={FewStatuses}/>
+         <Row title="Repo with Required Commit Status 'unit-tests'" pullDatas={RequiredStatuses}/>
          <Row title="Many Commit Statuses" pullDatas={ManyStatuses}/>
          <Row title="Blocked" pullDatas={Blocked}/>
          <Row title="Milestones" pullDatas={Milestones}/>

--- a/frontend/test/pull-data-parts.ts
+++ b/frontend/test/pull-data-parts.ts
@@ -50,7 +50,7 @@ export function sig(type : SignatureType, active: boolean, user?: string): Signa
    };
 }
 
-export function status(state?: keyof typeof StatusState, url?: string | null): CommitStatus {
+export function status(state?: keyof typeof StatusState, url?: string | null, context?: string | null): CommitStatus {
    const statusState = <StatusState>state || StatusState.success;
    return {
       "data": {
@@ -58,7 +58,7 @@ export function status(state?: keyof typeof StatusState, url?: string | null): C
          "target_url": url === undefined ? "https://www.example.com" : url,
          "description": "Build " + statusState,
          "state": statusState,
-         "context": statusContext(),
+         "context": context || statusContext(),
       }
    };
 }
@@ -66,7 +66,7 @@ export function status(state?: keyof typeof StatusState, url?: string | null): C
 export function pullData(p: DeepPartial<PullData>): PullData {
    return <PullData> {
       "repo": repo,
-      "repoSpec": null,
+      "repoSpec": p.repoSpec || null,
       "number": pullNumber(),
       "state": "open",
       "title": p.title || "Young pull with no CR / QA",

--- a/models/pull.js
+++ b/models/pull.js
@@ -12,7 +12,7 @@ function Pull(data, signatures, comments, reviews, commitStatuses, labels) {
    this.signatures = signatures || [];
    this.comments = comments || [];
    this.reviews = reviews || [];
-   this.commitStatuses = commitStatuses;
+   this.commitStatuses = commitStatuses || [];
    this.labels = labels || [];
 
    // If github pull-data, parse the body for the cr and qa req... else


### PR DESCRIPTION
If a pull doesn't have a required status, include a grey CI bubble
like the other CI statuses that says "Missing" to make it obvious which
one can't be found.

Think of it as a placeholder for an unmet requirement. Without this,
it's not obvious which of ~13 required statuses isn't present.

Closes #295

CC @davidrans @erinemay 