### PR TITLE
CR Leader List: have it show unique CRs in last 14 days

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,8 +46,10 @@ app.use("/", express.static(__dirname + '/frontend/dist'));
 app.get('/token',       mainController.getToken);
 app.post('/hooks/main', hooksController.main);
 
-debug("Loading all open pulls from the DB");
-dbManager.getOpenPulls().then(function(pulls) {
+debug("Loading all recent pulls from the DB");
+const includePullsClosedWithinDays = 14; // Keep the same or higher than the value in leader-list.tsx
+const recent = Date.now() / 1000 - 86400 * includePullsClosedWithinDays;
+dbManager.getRecentPulls(recent).then(function(pulls) {
    debug("Loaded %s pulls", pulls.length);
    pullQueue.pause();
    pulls.forEach(function(pull) {

--- a/app.js
+++ b/app.js
@@ -47,9 +47,8 @@ app.get('/token',       mainController.getToken);
 app.post('/hooks/main', hooksController.main);
 
 debug("Loading all recent pulls from the DB");
-const includePullsClosedWithinDays = 14; // Keep the same or higher than the value in leader-list.tsx
-const recent = Date.now() / 1000 - 86400 * includePullsClosedWithinDays;
-dbManager.getRecentPulls(recent).then(function(pulls) {
+dbManager.getRecentPulls(pullManager.getOldestAllowedPullTimestamp())
+.then(function(pulls) {
    debug("Loaded %s pulls", pulls.length);
    pullQueue.pause();
    pulls.forEach(function(pull) {

--- a/frontend/src/filter-menu.tsx
+++ b/frontend/src/filter-menu.tsx
@@ -1,4 +1,4 @@
-import { useAllPulls, useSetFilter } from './pulldasher/pulls-context';
+import { useAllOpenPulls, useSetFilter } from './pulldasher/pulls-context';
 import { useArrayUrlState } from './use-url-state';
 import { Pull } from './pull';
 import { useConst, Button, Menu, MenuButton, MenuList, MenuDivider, MenuOptionGroup, MenuItemOption } from "@chakra-ui/react";
@@ -15,7 +15,7 @@ type FilterMenuProps = {
 };
 
 export function FilterMenu({urlParam, buttonText, extractValueFromPull}: FilterMenuProps) {
-   const pulls = useAllPulls();
+   const pulls = useAllOpenPulls();
    // Default is empty array that implies show all pulls (no filtering)
    const [selectedValues, setSelectedValues] = useArrayUrlState(urlParam, []);
    // Nothing selected == show everything, otherwise, it'd be empty

--- a/frontend/src/leader-list.tsx
+++ b/frontend/src/leader-list.tsx
@@ -55,7 +55,7 @@ function colorForIndex(index: number): string {
 export function getLeaders(pulls: Pull[], extractSigsFromPull: (pull: Pull) => Signature[]) {
    const recent = toDateString(new Date(Date.now() - 86400 * 1000 * DAYS_TO_EXAMINE));
    const recentPulls = pulls.filter((pull) => {
-      return pull.merged_at ? pull.merged_at > recent : true;
+      return pull.closed_at ? pull.closed_at > recent : true;
    });
    const sigCounts = new Map<number, SigCount>();
    recentPulls.forEach((pull) => {

--- a/frontend/src/leader-list.tsx
+++ b/frontend/src/leader-list.tsx
@@ -22,6 +22,7 @@ export function LeaderList({leaders, title}: {leaders: SigCount[], title: string
          <chakra.span mb={1} flexShrink={0}>{title}:</chakra.span>
          {leaders.map(({user, count}, i) =>
             <HStack
+               title={user.login}
                overflow="hidden"
                borderRadius="4px"
                fontWeight="bold"

--- a/frontend/src/leader-list.tsx
+++ b/frontend/src/leader-list.tsx
@@ -1,4 +1,5 @@
 import { Pull } from './pull';
+import { toDateString } from './utils';
 import { Signature, SignatureUser } from './types';
 import { Flex, HStack, Box, chakra } from "@chakra-ui/react"
 
@@ -6,6 +7,8 @@ interface SigCount {
    user: SignatureUser;
    count: number;
 }
+
+const DAYS_TO_EXAMINE = 14;
 
 export function LeaderList({leaders, title}: {leaders: SigCount[], title: string}) {
    return (
@@ -49,16 +52,27 @@ function colorForIndex(index: number): string {
 }
 
 export function getLeaders(pulls: Pull[], extractSigsFromPull: (pull: Pull) => Signature[]) {
-   const signatures: Signature[] = pulls.flatMap(extractSigsFromPull);
-   const users = signatures.map((signature) => signature.data.user);
-   const groupedByUsers = users
-      .reduce((grouped: Map<number, SigCount>, user: SignatureUser) => {
-         const group = grouped.get(user.id) || {user, count:0};
-         group.count++;
-         grouped.set(user.id, group)
-         return grouped;
-      }, new Map())
-      .values();
-   return Array.from(groupedByUsers)
+   const recent = toDateString(new Date(Date.now() - 86400 * 1000 * DAYS_TO_EXAMINE));
+   const recentPulls = pulls.filter((pull) => {
+      return pull.merged_at ? pull.merged_at > recent : true;
+   });
+   const sigCounts = new Map<number, SigCount>();
+   recentPulls.forEach((pull) => {
+      const sigs: Signature[] = extractSigsFromPull(pull);
+      const recentSigs = sigs.filter((sig) => sig.data.created_at > recent);
+      // Count one sig per user from this pull
+      const seenUsers = new Set<number>();
+      recentSigs.forEach((sig) => {
+         const user = sig.data.user;
+         if (seenUsers.has(user.id)) {
+            return;
+         }
+         seenUsers.add(user.id);
+         const sigCount = sigCounts.get(user.id) || {user, count:0};
+         sigCount.count++;
+         sigCounts.set(user.id, sigCount)
+      });
+   });
+   return Array.from(sigCounts.values())
       .sort((a: SigCount, b: SigCount) => b.count - a.count);
 }

--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -1,4 +1,4 @@
-import { useAllPulls } from './pulls-context';
+import { useAllPulls, useAllOpenPulls } from './pulls-context';
 import { Navbar } from '../navbar';
 import { Column } from '../column';
 import { QACompare } from './sort';
@@ -6,14 +6,15 @@ import { LeaderList, getLeaders } from '../leader-list';
 import { Box, SimpleGrid, VStack } from "@chakra-ui/react"
 
 export const Pulldasher: React.FC = function() {
-   const pulls = useAllPulls();
+   const allPulls = useAllPulls();
+   const pulls = useAllOpenPulls();
    const pullsCIBlocked = pulls.filter(pull => pull.isCiBlocked());
    const pullsDeployBlocked = pulls.filter(pull => pull.isDeployBlocked());
    const pullsReady = pulls.filter(pull => pull.isReady() && pull.isCiRequired());
    const pullsDevBlocked = pulls.filter(pull => pull.getDevBlock());
    const pullsNeedingCR = pulls.filter(pull => !pull.isCrDone() && !pull.getDevBlock());
    const pullsNeedingQA = pulls.filter(pull => !pull.isQaDone() && !pull.getDevBlock() && pull.hasPassedCI());
-   const leadersCR = getLeaders(pulls, (pull) => pull.status.allCR);
+   const leadersCR = getLeaders(allPulls, (pull) => pull.status.allCR);
    return (<>
       <Navbar mb={4}/>
       <Box maxW="var(--body-max-width)" m="auto" px="var(--body-gutter)">

--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -13,7 +13,7 @@ export const Pulldasher: React.FC = function() {
    const pullsDevBlocked = pulls.filter(pull => pull.getDevBlock());
    const pullsNeedingCR = pulls.filter(pull => !pull.isCrDone() && !pull.getDevBlock());
    const pullsNeedingQA = pulls.filter(pull => !pull.isQaDone() && !pull.getDevBlock() && pull.hasPassedCI());
-   const leadersCR = getLeaders(pulls, (pull) => pull.cr_signatures.current);
+   const leadersCR = getLeaders(pulls, (pull) => pull.status.allCR);
    return (<>
       <Navbar mb={4}/>
       <Box maxW="var(--body-max-width)" m="auto" px="var(--body-gutter)">

--- a/frontend/src/pulldasher/pulls-context.tsx
+++ b/frontend/src/pulldasher/pulls-context.tsx
@@ -5,8 +5,10 @@ import { Pull } from '../pull';
 import { defaultCompare } from "./sort";
 
 interface PullContextProps {
-   // Array of all pulls
+   // Array of all pulls (open + recently closed)
    allPulls: Pull[];
+   // Array of all open pulls (open)
+   allOpenPulls: Pull[];
    // Set pf pulls passing the filter function
    pulls: Set<Pull>;
    // Changes the filter function
@@ -15,12 +17,17 @@ interface PullContextProps {
 
 const defaultProps = {
    allPulls: [],
+   allOpenPulls: [],
    pulls: new Set<Pull>(),
    // Default implementation is a no-op, just so there's
    // something there until the provider is used
    setFilter: (name:string, filter:FilterFunction) => filter,
 }
 export const PullsContext = createContext<PullContextProps>(defaultProps);
+
+export function useAllOpenPulls(): Pull[] {
+   return useContext(PullsContext).allOpenPulls;
+}
 
 export function useAllPulls(): Pull[] {
    return useContext(PullsContext).allPulls;
@@ -37,9 +44,11 @@ export function useSetFilter(): FilterFunctionSetter {
 export const PullsProvider = function({children}: {children: React.ReactNode}) {
    const unfilteredPulls = usePullsState();
    const [filteredPulls, setFilter] = useFilteredPullsState(unfilteredPulls);
+   const allOpenPulls = unfilteredPulls.filter((pull) => pull.isOpen());
    const sortedPulls = unfilteredPulls.sort(defaultCompare);
    const contextValue = {
       pulls: new Set(filteredPulls),
+      allOpenPulls: allOpenPulls,
       allPulls: sortedPulls,
       setFilter
    };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -48,7 +48,7 @@ export interface Signature {
       number: number;
       user: SignatureUser;
       type: SignatureType;
-      created_at: DateString | null;
+      created_at: DateString;
       active: number;
       comment_id: number;
       source_type: CommentSource;

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -13,3 +13,7 @@ function formatDate(date: DateString) {
    });
 }
 
+export function toDateString(date: Date): DateString {
+   return date.toISOString();
+}
+

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -379,14 +379,15 @@ var dbManager = module.exports = {
    /**
     * Returns a promise which resolves to an array of Pull objects for all open
     * and recently closed pulls from the DB.
-    * @param includeMergedSince: include pulls merged after this unix timestamp
+    * @param includeMergedSince: include pulls merged after this Date object
     */
    getRecentPulls: function(includeMergedSince) {
       var self = this;
+      const mergedSinceUnix = Math.floor(includeMergedSince.getTime() / 1000);
       debug('Calling getRecentPulls');
       var q_select = 'SELECT repo, number FROM pulls WHERE state = ? OR date_closed > ?';
 
-      return db.query(q_select, ['open', includeMergedSince]).then(function(rows) {
+      return db.query(q_select, ['open', mergedSinceUnix]).then(function(rows) {
          debug('Found %s open pulls in the DB', rows.length);
          if (rows.length === 0) { return []; }
          var pulls = _.map(rows, function(row) {

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -378,14 +378,15 @@ var dbManager = module.exports = {
 
    /**
     * Returns a promise which resolves to an array of Pull objects for all open
-    * pulls from the DB
+    * and recently closed pulls from the DB.
+    * @param includeMergedSince: include pulls merged after this unix timestamp
     */
-   getOpenPulls: function() {
+   getRecentPulls: function(includeMergedSince) {
       var self = this;
-      debug('Calling getOpenPulls');
-      var q_select = 'SELECT repo, number FROM pulls WHERE state = ?';
+      debug('Calling getRecentPulls');
+      var q_select = 'SELECT repo, number FROM pulls WHERE state = ? OR date_closed > ?';
 
-      return db.query(q_select, ['open']).then(function(rows) {
+      return db.query(q_select, ['open', includeMergedSince]).then(function(rows) {
          debug('Found %s open pulls in the DB', rows.length);
          if (rows.length === 0) { return []; }
          var pulls = _.map(rows, function(row) {

--- a/lib/pull-manager.js
+++ b/lib/pull-manager.js
@@ -8,6 +8,12 @@ var sockets = [];
 var pulls = [];
 
 var pullManager = module.exports = {
+   getOldestAllowedPullTimestamp: function() {
+      // Keep the same or higher than the value in leader-list.tsx
+      const includePullsClosedWithinDays = 14;
+      return Date.now() / 1000 - 86400 * includePullsClosedWithinDays;
+   },
+
    addSocket: function(socket) {
       sockets.push(socket);
       sendInitialData(socket);
@@ -21,14 +27,9 @@ var pullManager = module.exports = {
 
       if (pull) {
          _.extend(pull, updatedPull);
-         if (!pull.isOpen()) {
-            pulls = _.without(pulls, pull);
-         }
       } else {
          pull = updatedPull;
-         if (pull.isOpen()) {
-            pulls.push(pull);
-         }
+         pulls.push(pull);
       }
 
       notifyAboutPullStateChange(pull);
@@ -77,3 +78,13 @@ pullQueue.on('pullsChanged', function(pulls) {
       });
    });
 });
+
+// Cull old closed pulls from memory every once in a while
+setTimeout(() => {
+   const oldestAllowed = pullManager.getOldestAllowedPullTimestamp() * 1000;
+   pulls = pulls.filter((pull) =>
+      pull.isOpen() ||
+      !pull.data.closed_at ||
+      pull.data.closed_at.getTime() > oldestAllowed
+   );
+}, 3600 * 1000);

--- a/lib/pull-manager.js
+++ b/lib/pull-manager.js
@@ -11,7 +11,7 @@ var pullManager = module.exports = {
    getOldestAllowedPullTimestamp: function() {
       // Keep the same or higher than the value in leader-list.tsx
       const includePullsClosedWithinDays = 14;
-      return Date.now() / 1000 - 86400 * includePullsClosedWithinDays;
+      return new Date(Date.now() - 86400 * 1000 * includePullsClosedWithinDays);
    },
 
    addSocket: function(socket) {
@@ -81,10 +81,10 @@ pullQueue.on('pullsChanged', function(pulls) {
 
 // Cull old closed pulls from memory every once in a while
 setTimeout(() => {
-   const oldestAllowed = pullManager.getOldestAllowedPullTimestamp() * 1000;
+   const oldestAllowed = pullManager.getOldestAllowedPullTimestamp();
    pulls = pulls.filter((pull) =>
       pull.isOpen() ||
       !pull.data.closed_at ||
-      pull.data.closed_at.getTime() > oldestAllowed
+      pull.data.closed_at > oldestAllowed
    );
 }, 3600 * 1000);


### PR DESCRIPTION
The Leader list was not that helpful. It was showing the total
CR signature count across all pulls in pulldasher's memory (not the DB).
This wasn't that useful of a metric because that was an abritrary number
of pulls and 7 CRs on one pull isn't the same as 1 CR on 7 pulls.

Now:

* Only include open pulls and those merged less than 14 days ago.
* Only include signatures made in the last 14 days
* Count only the number of pulls each user has CRed (not the number of
  signatures)
* Avatars show username on hover

Future work:

* Change pulldasher to load even closed pulls from the DB so
  these numbers stay the same on restart.
   * Right now it only loads open pulls on restart
* Maybe: drop list and only show how you compare to mean or median of the
  group.
  
This is closer to your spec @davidrans 