### PR TITLE
Filter menu: put the divider in the right place

### DIFF
--- a/frontend/src/filter-menu.tsx
+++ b/frontend/src/filter-menu.tsx
@@ -51,6 +51,7 @@ export function FilterMenu({urlParam, buttonText, extractValueFromPull}: FilterM
           isChecked={showAll}>
           Show All
        </MenuItemOption>
+        <MenuDivider/>
         <MenuOptionGroup
            type='checkbox'
            value={showAll ? [] : selectedValues}
@@ -63,7 +64,6 @@ export function FilterMenu({urlParam, buttonText, extractValueFromPull}: FilterM
              </MenuItemOption>
           )}
        </MenuOptionGroup>
-       <MenuDivider/>
      </MenuList>
    </Menu>
    );


### PR DESCRIPTION
Bug: No divider -> 
![image](https://user-images.githubusercontent.com/26855/165809073-e2a9bd2c-be04-47f3-b4c6-dc786e55eaa5.png)

Divider in wrong place:
![image](https://user-images.githubusercontent.com/26855/165809197-f756671b-7334-424c-b008-2d68b5557d0b.png)

After:
![image](https://user-images.githubusercontent.com/26855/165809361-c212651b-1b02-40f7-a4b8-ffa64b62cf59.png)

cr_req 1