### PR TITLE
Pull card: add tooltip of timestamp to age indicator

### DIFF
--- a/frontend/src/pull-card/age.tsx
+++ b/frontend/src/pull-card/age.tsx
@@ -2,13 +2,15 @@ import { DateString } from '../types';
 import { Box } from "@chakra-ui/react"
 
 export function Age({created_at}: {created_at: DateString}) {
-   const timeDifference = Date.now() - new Date(created_at).getTime();
+   const createdAt = new Date(created_at);
+   const timeDifference = Date.now() - createdAt.getTime();
    const daysSinceCreation = Math.ceil(timeDifference / (1000 * 3600 * 24));
    const numDots = Math.min(daysSinceCreation, 30);
    const dot = "•";
+   const tooltip = `opened at ${createdAt.toLocaleString()}`;
 
    return (
-   <Box color={`var(${getAgeColor(daysSinceCreation)})`}>
+   <Box title={tooltip} color={`var(${getAgeColor(daysSinceCreation)})`}>
       {dot.repeat(numDots)}
    </Box>
    );


### PR DESCRIPTION
The age indicator is relative and coarse. Let's add a tooltip that gives
more specifics.

`"opened at 20/12/2012, 03:00:00"`