### PR TITLE
Avatars: support bots!

### DIFF
--- a/frontend/src/pull-card/index.tsx
+++ b/frontend/src/pull-card/index.tsx
@@ -94,6 +94,7 @@ function PullCard({pull, show}: {pull: Pull, show: boolean}) {
 });
 
 function Avatar({user}: {user: string}) {
+   const cleanUsername = user.replace(/\[bot\]$/, "");
    return <Img
       mr="7px"
       mb="1px"
@@ -103,6 +104,6 @@ function Avatar({user}: {user: string}) {
       borderRadius="full"
       verticalAlign="bottom"
       title={user}
-      src={`https://github.com/${user}.png?size=20`}
+      src={`https://github.com/${cleanUsername}.png?size=20`}
    />;
 }

--- a/frontend/test/pull-data-parts.ts
+++ b/frontend/test/pull-data-parts.ts
@@ -111,7 +111,8 @@ function pullNumber(): number {
 }
 
 function username(): string {
-   return "username-" + Math.floor(Math.random()*1000);
+   // Some static username so pulls still get a nice avatar
+   return "dependabot[bot]";
 }
 
 function statusContext(): string {


### PR DESCRIPTION
Apparently, usernames of bots come from github like "{name}[bot]"
and that "[bot]" part needs to be trimmed off when making an avatar url.