### PR TITLE
CI Status: move details into a popup

### DIFF
--- a/frontend/src/pull-card/commit-statuses.tsx
+++ b/frontend/src/pull-card/commit-statuses.tsx
@@ -83,7 +83,7 @@ function CommitStatuses({pull}: {pull: Pull}) {
    const statuses = pull.buildStatusesWithRequired();
    const grouped = groupBy(statuses, (status) => status.data.state);
    return (
-   <Popover>
+   <Popover isLazy>
       <PopoverTrigger>
           <StatusContainer className="build_status_container">
              {grouped.success &&

--- a/frontend/src/pull-card/commit-statuses.tsx
+++ b/frontend/src/pull-card/commit-statuses.tsx
@@ -85,6 +85,9 @@ function StatusGroup({statuses}: {statuses: CommitStatus[]}) {
 export const CommitStatuses = memo(
 function CommitStatuses({pull}: {pull: Pull}) {
    const statuses = pull.buildStatusesWithRequired();
+   if (statuses.length === 0) {
+      return null;
+   }
    const grouped = groupBy(statuses, (status) => status.data.state);
    return (
    <Popover isLazy>

--- a/frontend/src/pull-card/commit-statuses.tsx
+++ b/frontend/src/pull-card/commit-statuses.tsx
@@ -78,11 +78,26 @@ function CommitStatuses({pull}: {pull: Pull}) {
    <Popover>
       <PopoverTrigger>
           <StatusContainer className="build_status_container">
-             {Object.keys(grouped).map((state: StatusState) => (
+             {grouped.success &&
                 <StatusGroup
-                   key={state}
-                   statuses={grouped[state]} />
-             ))}
+                   key={StatusState.success}
+                   statuses={grouped.success} />
+             }
+             {grouped.pending &&
+                <StatusGroup
+                   key={StatusState.pending}
+                   statuses={grouped.pending} />
+             }
+             {grouped.failure &&
+                <StatusGroup
+                   key={StatusState.failure}
+                   statuses={grouped.failure} />
+             }
+             {grouped.error &&
+                <StatusGroup
+                   key={StatusState.error}
+                   statuses={grouped.error} />
+             }
           </StatusContainer>
       </PopoverTrigger>
       <Portal>

--- a/frontend/src/pull-card/commit-statuses.tsx
+++ b/frontend/src/pull-card/commit-statuses.tsx
@@ -45,6 +45,7 @@ function StatusLink({status}: {status: CommitStatus}) {
    return (
       <StatusLinkContainer
          __css={styles}
+         title={status.data.state}
          cursor={link ? "pointer" : "auto"}
          onClick={link ? () => newTab(link) : undefined}
       >

--- a/frontend/src/pull-card/commit-statuses.tsx
+++ b/frontend/src/pull-card/commit-statuses.tsx
@@ -38,7 +38,10 @@ const StatusContainer = styled.div`
 
 function StatusLink({status}: {status: CommitStatus}) {
    const styles = useStyleConfig('StatusLink', {variant: status.data.state});
-   const title = status.data.context + ": " + status.data.description;
+   const description = status.data.description === status.data.state
+      ? ""
+      : status.data.description;
+   const title = status.data.context + description;
    return (status.data.target_url ?
       <chakra.a
          __css={styles}

--- a/frontend/src/pull-card/commit-statuses.tsx
+++ b/frontend/src/pull-card/commit-statuses.tsx
@@ -90,26 +90,10 @@ function CommitStatuses({pull}: {pull: Pull}) {
    <Popover isLazy>
       <PopoverTrigger>
           <StatusContainer className="build_status_container">
-             {grouped.success &&
-                <StatusGroup
-                   key={StatusState.success}
-                   statuses={grouped.success} />
-             }
-             {grouped.pending &&
-                <StatusGroup
-                   key={StatusState.pending}
-                   statuses={grouped.pending} />
-             }
-             {grouped.failure &&
-                <StatusGroup
-                   key={StatusState.failure}
-                   statuses={grouped.failure} />
-             }
-             {grouped.error &&
-                <StatusGroup
-                   key={StatusState.error}
-                   statuses={grouped.error} />
-             }
+             {grouped.success && <StatusGroup statuses={grouped.success}/> }
+             {grouped.pending && <StatusGroup statuses={grouped.pending}/> }
+             {grouped.failure && <StatusGroup statuses={grouped.failure}/> }
+             {grouped.error && <StatusGroup statuses={grouped.error}/> }
           </StatusContainer>
       </PopoverTrigger>
       <Portal>

--- a/frontend/src/pull-card/commit-statuses.tsx
+++ b/frontend/src/pull-card/commit-statuses.tsx
@@ -50,8 +50,11 @@ function StatusLink({status}: {status: CommitStatus}) {
          onClick={link ? () => newTab(link) : undefined}
       >
          <FontAwesomeIcon size="lg" icon={iconForStatus(status)}/>
-         <chakra.span ml="10px" color="black">
-            {status.data.context}: {status.data.description}
+         <chakra.span fontWeight="bold">
+            {status.data.context}:
+         </chakra.span>
+         <chakra.span>
+            {status.data.description}
          </chakra.span>
       </StatusLinkContainer>
    );

--- a/frontend/src/pull-card/commit-statuses.tsx
+++ b/frontend/src/pull-card/commit-statuses.tsx
@@ -12,6 +12,7 @@ import {
    PopoverArrow,
    PopoverCloseButton,
    Portal,
+   BoxProps,
 } from "@chakra-ui/react"
 import { groupBy } from 'lodash-es';
 import { memo } from "react"
@@ -68,17 +69,33 @@ function iconForStatus(status: CommitStatus): IconDefinition {
       : faCircleCheck;
 }
 
-function StatusGroup({statuses}: {statuses: CommitStatus[]}) {
+type StatusGroupProps = BoxProps & {
+   statuses: CommitStatus[];
+}
+
+function StatusGroup({statuses, ...props}: StatusGroupProps) {
    const state = statuses[0].data.state;
    const styles = useStyleConfig('StatusGroup', {variant: state});
    const contexts = statuses.map(status => status.data.context).join("\n");
    const title = `${state}:${statuses.length > 1 ? "\n" : " "}${contexts}`;
    return (
       <Box __css={styles}
+         {...props}
          flexBasis={1 + statuses.length}
          title={title}
          className="build_status"
       />
+   );
+}
+
+function SingleStatus(status: CommitStatus) {
+   const link = status.data.target_url;
+   return (
+    <StatusContainer className="build_status_container">
+      <StatusGroup
+         onClick={link ? () => newTab(link) : undefined}
+         statuses={[status]}/>
+    </StatusContainer>
    );
 }
 
@@ -87,6 +104,8 @@ function CommitStatuses({pull}: {pull: Pull}) {
    const statuses = pull.buildStatusesWithRequired();
    if (statuses.length === 0) {
       return null;
+   } else if (statuses.length === 1) {
+      return SingleStatus(statuses[0]);
    }
    const grouped = groupBy(statuses, (status) => status.data.state);
    return (

--- a/frontend/src/pull-card/index.tsx
+++ b/frontend/src/pull-card/index.tsx
@@ -5,7 +5,7 @@ import { Age } from './age';
 import { Flags } from './flags';
 import { Signatures } from './signatures';
 import { CopyBranch } from './copy-branch';
-import { memo, useEffect, useRef } from "react";
+import { memo, useEffect, useRef, RefObject } from "react";
 import { RefreshButton } from './refresh';
 import { Flex, Box, Link, chakra, Img } from "@chakra-ui/react"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -51,13 +51,7 @@ const SigsAndFlags = chakra(Flex, {
 export const PullCard = memo(
 function PullCard({pull, show}: {pull: Pull, show: boolean}) {
    const cardRef = useRef<HTMLElement>(null);
-
-   // Animate a highlight when pull.received_at changes
-   useEffect(() => {
-      cardRef.current?.classList.add("highlight");
-      // 1s after the animation, remove the class
-      setTimeout(() => cardRef.current?.classList.remove("highlight"), 3000);
-   }, [pull.received_at]);
+   highlightOnChange(cardRef, [pull.received_at]);
 
    return (
       <Card ref={cardRef} display={show ? undefined : "none"}>
@@ -118,4 +112,14 @@ function avatarClickHandler(event: React.MouseEvent<HTMLElement>) {
    }
    window.open(userProfileUrl(user), "_blank");
    event.preventDefault();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function highlightOnChange(ref: RefObject<HTMLElement>, dependencies: Array<any>) {
+   // Animate a highlight when pull.received_at changes
+   useEffect(() => {
+      ref.current?.classList.add("highlight");
+      // 1s after the animation, remove the class
+      setTimeout(() => ref.current?.classList.remove("highlight"), 3000);
+   }, dependencies);
 }

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -1,3 +1,4 @@
+import { sortBy } from "lodash-es";
 import { getUser } from "./page-context";
 import { PullData, Signature, CommitStatus, StatusState, CommentSource, SignatureGroup } from "./types";
 
@@ -129,7 +130,7 @@ export class Pull extends PullData {
             });
          }
       });
-      return statuses;
+      return sortBy(statuses, ['data.context']);
    }
 
    getRequiredBuildStatuses(): string[] {

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -130,7 +130,7 @@ export class Pull extends PullData {
             });
          }
       });
-      return sortBy(statuses, ['data.context']);
+      return sortBy(statuses, [status => status.data.context.toLowerCase()]);
    }
 
    getRequiredBuildStatuses(): string[] {

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -106,6 +106,7 @@ export const theme = extendTheme({
             padding: "5px",
             "> span": {
                color: "var(--build-status-text)",
+               marginLeft: "10px",
             },
             "&:hover": {
                "background": "rgb(128,128,128,0.1)",

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -71,12 +71,11 @@ export const theme = extendTheme({
             }
          }
       },
-      Status: {
+      StatusGroup: {
          baseStyle: {
             display: "block",
             pos: "relative",
             w: "100%",
-            height: "10px",
             opacity: 1,
             flexGrow: 1,
             transition: "opacity 0.3s ease-in-out",
@@ -92,6 +91,29 @@ export const theme = extendTheme({
             },
             error: {
                bg: "var(--build-state-error)",
+            },
+            failure: {
+               bg: "var(--build-state-failure)",
+            },
+         }
+      },
+      StatusLink: {
+         baseStyle: {
+            display: "block",
+            borderRadius: "5px",
+            padding: "3px 10px",
+            width: "100%",
+         },
+         variants: {
+            pending: {
+               bg: "var(--build-state-pending)",
+            },
+            success: {
+               bg: "var(--build-state-success)",
+            },
+            error: {
+               bg: "var(--build-state-error)",
+               color: "white",
             },
             failure: {
                bg: "var(--build-state-failure)",

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -99,24 +99,30 @@ export const theme = extendTheme({
       },
       StatusLink: {
          baseStyle: {
-            display: "block",
-            borderRadius: "5px",
-            padding: "3px 10px",
-            width: "100%",
+            borderBottom: "1px solid var(--build-status-link-divider)",
+            "&:last-child": {
+               borderBottom: "none",
+            },
+            padding: "5px",
+            "> span": {
+               color: "var(--build-status-text)",
+            },
+            "&:hover": {
+               "background": "rgb(128,128,128,0.1)",
+            }
          },
          variants: {
             pending: {
-               bg: "var(--build-state-pending)",
+               color: "var(--build-state-pending)",
             },
             success: {
-               bg: "var(--build-state-success)",
+               color: "var(--build-state-success)",
             },
             error: {
-               bg: "var(--build-state-error)",
-               color: "white",
+               color: "var(--build-state-error)",
             },
             failure: {
-               bg: "var(--build-state-failure)",
+               color: "var(--build-state-failure)",
             },
          }
       },

--- a/frontend/src/theme/day_theme.less
+++ b/frontend/src/theme/day_theme.less
@@ -88,6 +88,8 @@ body[data-theme="day_theme"] {
     --build-state-failure: @yellow;
     --build-state-error:   @red;
     --build-state-success: @green;
+    --build-status-link-divider: @grey;
+    --build-status-text: @dark-grey;
 
     --tag-default-border: darken(@light-grey, 10%);
     --tag-default-background: @white;

--- a/frontend/src/theme/night_theme.less
+++ b/frontend/src/theme/night_theme.less
@@ -93,6 +93,8 @@ body[data-theme="night_theme"] {
     --build-state-failure: @yellow;
     --build-state-error:   @red;
     --build-state-success: @green;
+    --build-status-link-divider: @grey;
+    --build-status-text: @light-grey;
 
     --tag-default-border: @dark-grey;
     --tag-default-background: @dark-grey;

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -22,3 +22,7 @@ export function userProfileUrl(username: string): string {
    const safeUsername = encodeURIComponent(debottedName);
    return `https://github.com/${safeUsername}`;
 }
+
+export function newTab(url: string) {
+   window.open(url, "_blank");
+}


### PR DESCRIPTION
See discussion: https://github.com/iFixit/pulldasher/discussions/316

When we have lots of CI statuses (we currently have 15 or so), the current UI works very poorly. This change moves most of it into a popup.

CI Status UI
====
* Use existing UI to represent *groups* of CI builds with the same state, roughly scaling with number in the group
* Keep them in a consistent order with green on top
* Clicking on any group opens the popup
* Hovering shows the list of statuses in that state

Popup:
====
* Consistent ordering (alpha)
* Icon and color both represent build state

**Popup:**
![image](https://user-images.githubusercontent.com/26855/168636908-59fca0df-80c6-46ec-9cce-d60c43deb300.png)

**Hover state**
![image](https://user-images.githubusercontent.com/26855/168636784-5253dec9-aa0e-4bf3-ac2e-b924587e30b8.png)