### PR TITLE
Frontend dev: stop socket io connection

### DIFF
--- a/frontend/src/backend/pull-socket.ts
+++ b/frontend/src/backend/pull-socket.ts
@@ -1,10 +1,10 @@
 import { Pull } from '../pull';
 import { getSocket } from './socket';
 import { PullData, RepoSpec } from  '../types';
+import { dummyPulls } from  '../utils';
 
 type PullUpdater = (pullDatas: PullData[], repoSpecs: RepoSpec[]) => void;
 let repoSpecs: RepoSpec[] = [];
-export const dummyPulls: PullData[] = (process.env.DUMMY_PULLS || []) as PullData[];
 
 /**
  * connects to the backend and calls the callback each time we receive

--- a/frontend/src/backend/socket.ts
+++ b/frontend/src/backend/socket.ts
@@ -1,6 +1,7 @@
 import { getPageContext } from '../page-context';
 import { io, Socket } from 'socket.io-client';
 import { useState, useEffect } from 'react';
+import { hasDummyPulls } from  '../utils';
 
 type SocketIO = Socket;
 
@@ -30,6 +31,9 @@ export enum ConnectionState {
 
 export function useConnectionState(): ConnectionState {
    const [state, setState] = useState<ConnectionState>(ConnectionState.connecting);
+   if (hasDummyPulls()) {
+      return ConnectionState.connected;
+   }
    useEffect(() => listenForConnectionEvents(setState), [getSocket()]);
    return state;
 }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,4 +1,4 @@
-import { DateString } from './types';
+import { DateString, PullData } from './types';
 
 export function actionMessage(action: string, date: DateString | null, user: string): string {
    return date ?
@@ -22,3 +22,5 @@ export function userProfileUrl(username: string): string {
    const safeUsername = encodeURIComponent(debottedName);
    return `https://github.com/${safeUsername}`;
 }
+
+export const dummyPulls: PullData[] = (process.env.DUMMY_PULLS || []) as PullData[];

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -24,3 +24,6 @@ export function userProfileUrl(username: string): string {
 }
 
 export const dummyPulls: PullData[] = (process.env.DUMMY_PULLS || []) as PullData[];
+export function hasDummyPulls() {
+   return dummyPulls.length > 0;
+}


### PR DESCRIPTION
We didn't use to try connecting to the socket when only running the frontend in dev mode, but then we added the connection state display #315 and accidentally started attempting a connection.

Here, we fake the connection status when in dev mode. Previously, when running `frontend:start` we were getting one 404 on the client every 10s or so, now we don't.