### PR TITLE
Filters: Fix filter forgetting bug

### DIFF
--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -57,8 +57,12 @@ export function Navbar(props: BoxProps) {
                   onClick={toggleColorMode}>
                   <FontAwesomeIcon icon={faMoon}/>
                </Button>
-               <FilterMenu urlParam="repo" buttonText="Repo" extractValueFromPull={(pull: Pull) => pull.getRepoName()}/>
-               <FilterMenu urlParam="author" buttonText="Author" extractValueFromPull={(pull: Pull) => pull.user.login}/>
+               <Box>
+                  <FilterMenu urlParam="repo" buttonText="Repo" extractValueFromPull={(pull: Pull) => pull.getRepoName()}/>
+               </Box>
+               <Box>
+                  <FilterMenu urlParam="author" buttonText="Author" extractValueFromPull={(pull: Pull) => pull.user.login}/>
+               </Box>
             </HStack>
             <Flex alignSelf="center" fontSize={20} flexShrink={0}>
                <span style={{fontVariantCaps: "small-caps"}}>Pulldasher</span>

--- a/frontend/src/pulldasher/filtered-pulls-state.ts
+++ b/frontend/src/pulldasher/filtered-pulls-state.ts
@@ -20,13 +20,18 @@ export function useFilteredPullsState(pulls: Pull[]): ReturnType {
    const [filters, setFilter] = useState<Filters>(defaultFilters);
    const replaceNamedFilter =
       (filterName:string, filter:FilterFunction|null) => {
-         if (filter) {
-            filters[filterName] = filter;
-         } else {
-            delete filters[filterName];
-         }
-         setTimeout(() => setFilter({...filters}), 0);
+         // Use the functional form of `setState()` so we can base our new
+         // value on the previous one.
+         setFilter((currentFilters) => {
+            if (filter) {
+               currentFilters[filterName] = filter;
+            } else {
+               delete currentFilters[filterName];
+            }
+            return {...currentFilters};
+         });
       };
+
    return [
       filterPulls(pulls, filters),
       replaceNamedFilter,

--- a/frontend/src/pulldasher/filtered-pulls-state.ts
+++ b/frontend/src/pulldasher/filtered-pulls-state.ts
@@ -18,8 +18,7 @@ const defaultFilters = {
  */
 export function useFilteredPullsState(pulls: Pull[]): ReturnType {
    const [filters, setFilter] = useState<Filters>(defaultFilters);
-   return [
-      filterPulls(pulls, filters),
+   const replaceNamedFilter =
       (filterName:string, filter:FilterFunction|null) => {
          if (filter) {
             filters[filterName] = filter;
@@ -27,7 +26,10 @@ export function useFilteredPullsState(pulls: Pull[]): ReturnType {
             delete filters[filterName];
          }
          setTimeout(() => setFilter({...filters}), 0);
-      }
+      };
+   return [
+      filterPulls(pulls, filters),
+      replaceNamedFilter,
    ];
 }
 

--- a/frontend/src/pulldasher/filtered-pulls-state.ts
+++ b/frontend/src/pulldasher/filtered-pulls-state.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Pull } from  '../pull';
 
 export type FilterFunction = (pull: Pull) => boolean;
@@ -18,7 +18,7 @@ const defaultFilters = {
  */
 export function useFilteredPullsState(pulls: Pull[]): ReturnType {
    const [filters, setFilter] = useState<Filters>(defaultFilters);
-   const replaceNamedFilter =
+   const replaceNamedFilter = useCallback(
       (filterName:string, filter:FilterFunction|null) => {
          // Use the functional form of `setState()` so we can base our new
          // value on the previous one.
@@ -30,7 +30,9 @@ export function useFilteredPullsState(pulls: Pull[]): ReturnType {
             }
             return {...currentFilters};
          });
-      };
+      },
+      []
+   );
 
    return [
       filterPulls(pulls, filters),


### PR DESCRIPTION
There was a bug and this fixes it (See commits for more technical details)

Repro the bug on master:

1. Load the page
2. Click the author menu
3. Choose an author
4. Notice pulls are filtered to that author
5. Press `/` to focus the search box
6. Type something that's in *many* pulls like `s`
7. Notice pulls are no longer filtered by author even though the menu is still selected

On this branch:

7. Pulls are filtered by author *and* search

Note this is built on #319 