### PR TITLE
Commit status: tweak bubble sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 node_modules
 pulldasher.pid
 dist
+db_data/
 /.env.db

--- a/frontend/src/pull-card/commit-statuses.tsx
+++ b/frontend/src/pull-card/commit-statuses.tsx
@@ -81,7 +81,7 @@ function StatusGroup({statuses, ...props}: StatusGroupProps) {
    return (
       <Box __css={styles}
          {...props}
-         flexBasis={1 + statuses.length}
+         flexGrow={1 + statuses.length}
          title={title}
          className="build_status"
       />

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -77,7 +77,6 @@ export const theme = extendTheme({
             pos: "relative",
             w: "100%",
             opacity: 1,
-            flexGrow: 1,
             transition: "opacity 0.3s ease-in-out",
             borderRadius: "5px",
          },


### PR DESCRIPTION
The CI bubbles now scale with the number of status in that state. Previously, the relative scaling was unpredictable.

Closes #321 


**Before:**
![image](https://user-images.githubusercontent.com/26855/168977830-d5a4a00b-0a47-4dc4-a975-c1fd5972e8aa.png)


**After:**
![image](https://user-images.githubusercontent.com/26855/168977564-1827043f-40b9-4d03-8753-505779c4dd35.png)
