### PR TITLE
Signatures: Only show one per requirement

### DIFF
--- a/frontend/src/pull-card/avatar.tsx
+++ b/frontend/src/pull-card/avatar.tsx
@@ -1,0 +1,28 @@
+import { Img } from "@chakra-ui/react"
+import { userProfileUrl } from '../utils';
+
+export function Avatar({user}: {user: string}) {
+   const cleanUsername = user.replace(/\[bot\]$/, "");
+   return <Img
+      data-user={user}
+      onClick={avatarClickHandler}
+      mr="7px"
+      mb="1px"
+      height="20px"
+      width="20px"
+      display="inline-block"
+      borderRadius="full"
+      verticalAlign="bottom"
+      title={user}
+      src={`https://github.com/${cleanUsername}.png?size=20`}
+   />;
+}
+
+function avatarClickHandler(event: React.MouseEvent<HTMLElement>) {
+   const user: string | undefined = event.currentTarget?.dataset.user;
+   if (!user) {
+      return;
+   }
+   window.open(userProfileUrl(user), "_blank");
+   event.preventDefault();
+}

--- a/frontend/src/pull-card/avatar.tsx
+++ b/frontend/src/pull-card/avatar.tsx
@@ -1,11 +1,11 @@
 import { Img } from "@chakra-ui/react"
 import { userProfileUrl } from '../utils';
 
-export function Avatar({user}: {user: string}) {
+export function Avatar({user, linkToProfile}: {user: string, linkToProfile?: boolean}) {
    const cleanUsername = user.replace(/\[bot\]$/, "");
    return <Img
       data-user={user}
-      onClick={avatarClickHandler}
+      onClick={linkToProfile ? avatarClickHandler : undefined}
       mr="7px"
       mb="1px"
       height="20px"

--- a/frontend/src/pull-card/index.tsx
+++ b/frontend/src/pull-card/index.tsx
@@ -61,7 +61,7 @@ function PullCard({pull, show}: {pull: Pull, show: boolean}) {
             <Link href={pull.getUrl()} title={pull.user.login} isExternal color="var(--pull-title)">
                {pull.isMine() ?
                <FontAwesomeIcon icon={faStar} className="star" color="var(--user-icon)"/> :
-               <Avatar user={pull.user.login}/>}
+               <Avatar user={pull.user.login} linkToProfile/>}
                <chakra.span fontWeight="bold">{pull.getRepoName()} #{pull.number}: </chakra.span>
                {pull.title}
             </Link>

--- a/frontend/src/pull-card/index.tsx
+++ b/frontend/src/pull-card/index.tsx
@@ -1,13 +1,13 @@
 import { Pull } from '../pull';
-import { userProfileUrl } from '../utils';
 import { CommitStatuses } from './commit-statuses';
 import { Age } from './age';
 import { Flags } from './flags';
+import { Avatar } from './avatar';
 import { Signatures } from './signatures';
 import { CopyBranch } from './copy-branch';
 import { memo, useEffect, useRef, RefObject } from "react";
 import { RefreshButton } from './refresh';
-import { Flex, Box, Link, chakra, Img } from "@chakra-ui/react"
+import { Flex, Box, Link, chakra } from "@chakra-ui/react"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faStar } from '@fortawesome/free-solid-svg-icons'
 
@@ -87,32 +87,6 @@ function PullCard({pull, show}: {pull: Pull, show: boolean}) {
       </Card>
    );
 });
-
-function Avatar({user}: {user: string}) {
-   const cleanUsername = user.replace(/\[bot\]$/, "");
-   return <Img
-      data-user={user}
-      onClick={avatarClickHandler}
-      mr="7px"
-      mb="1px"
-      height="20px"
-      width="20px"
-      display="inline-block"
-      borderRadius="full"
-      verticalAlign="bottom"
-      title={user}
-      src={`https://github.com/${cleanUsername}.png?size=20`}
-   />;
-}
-
-function avatarClickHandler(event: React.MouseEvent<HTMLElement>) {
-   const user: string | undefined = event.currentTarget?.dataset.user;
-   if (!user) {
-      return;
-   }
-   window.open(userProfileUrl(user), "_blank");
-   event.preventDefault();
-}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function highlightOnChange(ref: RefObject<HTMLElement>, dependencies: Array<any>) {

--- a/frontend/src/pull-card/signatures.tsx
+++ b/frontend/src/pull-card/signatures.tsx
@@ -34,6 +34,7 @@ function SignaturesFlag({pull, title, signatures, required}: SignaturesProps) {
       (pull.isMine() ? 'validMine' : 'valid') : undefined;
    const styles = useStyleConfig('Signatures', {variant: statusVariant});
    const allSignatures = [...signatures.current, ...signatures.old];
+   const requiredSignatures = required ? allSignatures.slice(0, required) : allSignatures;
    const unfulfilledCount = Math.max(0, required - allSignatures.length);
    const noneToShow = required == 0 && allSignatures.length == 0;
 
@@ -48,7 +49,8 @@ function SignaturesFlag({pull, title, signatures, required}: SignaturesProps) {
          title={noneToShow ? `No ${title} Required` : ''}
       >
          <Box m="2px" mr={noneToShow ? "2px" : 2}>{title}</Box>
-         {allSignatures.map((sig) => <SignatureBubble pull={pull} sig={sig}/>)}
+         {requiredSignatures.map((sig) =>
+            <SignatureBubble key={sig.data.created_at} pull={pull} sig={sig}/>)}
          {UnfullfilledSigs(unfulfilledCount)}
       </HStack>
    );

--- a/frontend/src/pull-card/signatures.tsx
+++ b/frontend/src/pull-card/signatures.tsx
@@ -66,9 +66,9 @@ function Signatures(props: SignaturesProps) {
    }
 
    return (
-   <Popover>
+   <Popover isLazy>
       <PopoverTrigger>
-         <Box>
+         <Box cursor="pointer">
             <SignaturesFlag {...props}/>
          </Box>
       </PopoverTrigger>

--- a/frontend/src/pull-card/signatures.tsx
+++ b/frontend/src/pull-card/signatures.tsx
@@ -1,7 +1,21 @@
 import { getUser } from '../page-context';
 import { Pull } from '../pull';
+import { Avatar } from './avatar';
+import { formatDate } from '../utils';
 import { Signature, SignatureGroup } from '../types';
-import { Box, HStack, useStyleConfig } from "@chakra-ui/react"
+import {
+   chakra,
+   Box,
+   HStack,
+   useStyleConfig,
+   Popover,
+   PopoverTrigger,
+   PopoverContent,
+   PopoverBody,
+   PopoverArrow,
+   PopoverCloseButton,
+   Portal,
+} from "@chakra-ui/react"
 import { memo } from "react"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
@@ -13,8 +27,9 @@ interface SignaturesProps {
    required: number,
 }
 
-export const Signatures = memo(
-function Signatures({pull, title, signatures, required}: SignaturesProps) {
+const SigSectionTitle = Box;
+
+function SignaturesFlag({pull, title, signatures, required}: SignaturesProps) {
    const statusVariant = signatures.current.length >= required ?
       (pull.isMine() ? 'validMine' : 'valid') : undefined;
    const styles = useStyleConfig('Signatures', {variant: statusVariant});
@@ -32,10 +47,54 @@ function Signatures({pull, title, signatures, required}: SignaturesProps) {
          sx={styles}
          title={noneToShow ? `No ${title} Required` : ''}
       >
-      <Box m="2px" mr={noneToShow ? "2px" : 2}>{title}</Box>
-      {NewAndOldSigs(allSignatures, pull)}
-      {UnfullfilledSigs(unfulfilledCount)}
-   </HStack>
+         <Box m="2px" mr={noneToShow ? "2px" : 2}>{title}</Box>
+         {NewAndOldSigs(allSignatures, pull)}
+         {UnfullfilledSigs(unfulfilledCount)}
+      </HStack>
+   );
+}
+
+export const Signatures = memo(
+function Signatures(props: SignaturesProps) {
+   const {pull, signatures} = props;
+   const noSignatures = (signatures.current.length === 0) && (signatures.old.length === 0);
+
+   if (noSignatures) {
+      return <SignaturesFlag {...props}/>;
+   }
+
+   return (
+   <Popover>
+      <PopoverTrigger>
+         <Box>
+            <SignaturesFlag {...props}/>
+         </Box>
+      </PopoverTrigger>
+      <Portal>
+         <PopoverContent>
+            <PopoverArrow />
+            <PopoverCloseButton />
+            <PopoverBody>
+               {signatures.current.length > 0 && (
+                  <>
+                     <SigSectionTitle color="var(--signature-valid)">
+                        Signed Off
+                     </SigSectionTitle>
+                     <SignatureList sigs={signatures.current} pull={pull}/>
+                  </>
+               )}
+               {signatures.old.length > 0 && (
+                  <>
+                     <SigSectionTitle color="var(--signature-invalid)">
+                        Previously Signed Off
+                     </SigSectionTitle>
+                     <SignatureList sigs={signatures.old} pull={pull}/>
+                  </>
+               )}
+            </PopoverBody>
+         </PopoverContent>
+      </Portal>
+   </Popover>
    );
 });
 
@@ -66,6 +125,23 @@ function UnfullfilledSigs(count: number) {
          icon={faCheckCircle}/>);
    }
    return sigs;
+}
+
+function SignatureList({sigs, pull}: {sigs: Signature[], pull: Pull}) {
+   return <Box>{sigs.map(sig =>
+      <SignatureListItem key={String(sig.data.created_at)} sig={sig} pull={pull}/>
+   )}</Box>;
+}
+
+function SignatureListItem({sig, pull}: {sig: Signature, pull: Pull}) {
+   const styles = useStyleConfig('SignatureListItem');
+   return (<chakra.a
+      __css={styles}
+      target="_blank"
+      href={pull.linkToSignature(sig)}>
+      <Avatar user={sig.data.user.login}/>
+      {formatDate(sig.data.created_at)} by {sig.data.user.login}
+   </chakra.a>);
 }
 
 function colorForSignature(sig: Signature): string {

--- a/frontend/src/pull-card/signatures.tsx
+++ b/frontend/src/pull-card/signatures.tsx
@@ -50,7 +50,7 @@ function SignaturesFlag({pull, title, signatures, required}: SignaturesProps) {
       >
          <Box m="2px" mr={noneToShow ? "2px" : 2}>{title}</Box>
          {requiredSignatures.map((sig) =>
-            <SignatureBubble key={sig.data.created_at} pull={pull} sig={sig}/>)}
+            <SignatureBubble key={sig.data.created_at} sig={sig}/>)}
          {UnfullfilledSigs(unfulfilledCount)}
       </HStack>
    );
@@ -100,10 +100,9 @@ function Signatures(props: SignaturesProps) {
    );
 });
 
-function SignatureBubble({sig, pull}: {sig: Signature, pull: Pull}) {
+function SignatureBubble({sig}: {sig: Signature}) {
    return (<a
-      key={sig.data.comment_id}
-      href={pull.linkToSignature(sig)}>
+      key={sig.data.comment_id}>
       <FontAwesomeIcon
          fontSize="18px"
          color={colorForSignature(sig)}

--- a/frontend/src/pull-card/signatures.tsx
+++ b/frontend/src/pull-card/signatures.tsx
@@ -48,7 +48,7 @@ function SignaturesFlag({pull, title, signatures, required}: SignaturesProps) {
          title={noneToShow ? `No ${title} Required` : ''}
       >
          <Box m="2px" mr={noneToShow ? "2px" : 2}>{title}</Box>
-         {NewAndOldSigs(allSignatures, pull)}
+         {allSignatures.map((sig) => <SignatureBubble pull={pull} sig={sig}/>)}
          {UnfullfilledSigs(unfulfilledCount)}
       </HStack>
    );
@@ -98,20 +98,17 @@ function Signatures(props: SignaturesProps) {
    );
 });
 
-function NewAndOldSigs(allSignatures: Signature[], pull: Pull) {
-   return allSignatures.map((sig) => {
-      return (<a
-         key={sig.data.comment_id}
-         href={pull.linkToSignature(sig)}>
-         <FontAwesomeIcon
-            fontSize="18px"
-            color={colorForSignature(sig)}
-            title={sig.data.user.login}
-            className="build_status"
-            icon={faCheckCircle}/>
-      </a>
-      )
-   });
+function SignatureBubble({sig, pull}: {sig: Signature, pull: Pull}) {
+   return (<a
+      key={sig.data.comment_id}
+      href={pull.linkToSignature(sig)}>
+      <FontAwesomeIcon
+         fontSize="18px"
+         color={colorForSignature(sig)}
+         title={sig.data.user.login}
+         className="build_status"
+         icon={faCheckCircle}/>
+   </a>);
 }
 
 function UnfullfilledSigs(count: number) {

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -178,7 +178,8 @@ function computeSignatures(signatures: Signature[]): SignatureGroup {
 }
 
 function activeSignaturesFirst(a: Signature, b: Signature): number {
-   return b.data.active - a.data.active;
+   return b.data.active - a.data.active ||
+      a.data.created_at.localeCompare(b.data.created_at);
 }
 
 function isSuccessfulStatus(status: CommitStatus) {

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -1,5 +1,6 @@
 import { sortBy } from "lodash-es";
 import { getUser } from "./page-context";
+import { signatureCompare } from "./pulldasher/sort";
 import { PullData, Signature, CommitStatus, StatusState, CommentSource, SignatureGroup } from "./types";
 
 export class Pull extends PullData {
@@ -159,7 +160,7 @@ function computeSignatures(signatures: Signature[]): SignatureGroup {
    const users: Record<string, boolean> = {};
 
    signatures
-   .sort(activeSignaturesFirst)
+   .sort(signatureCompare)
    .forEach(function(signature) {
       if (users[signature.data.user.login]) {
          return;
@@ -175,11 +176,6 @@ function computeSignatures(signatures: Signature[]): SignatureGroup {
    });
 
    return groups;
-}
-
-function activeSignaturesFirst(a: Signature, b: Signature): number {
-   return b.data.active - a.data.active ||
-      a.data.created_at.localeCompare(b.data.created_at);
 }
 
 function isSuccessfulStatus(status: CommitStatus) {

--- a/frontend/src/pulldasher/sort.ts
+++ b/frontend/src/pulldasher/sort.ts
@@ -1,5 +1,6 @@
 import { Pull } from '../pull';
 import { getUser } from "../page-context";
+import { Signature } from '../types';
 
 export function defaultCompare(a: Pull, b: Pull): number {
    return (
@@ -24,6 +25,15 @@ export function QACompare(a: Pull, b: Pull): number {
       compareBool(a.isCrDone(), b.isCrDone()) ||
       // Older pulls before younger pulls
       a.created_at.localeCompare(b.created_at)
+   );
+}
+
+export function signatureCompare(a: Signature, b: Signature) {
+   return (
+      // Active before inactive
+      b.data.active - a.data.active ||
+      // Older before newer
+      a.data.created_at.localeCompare(b.data.created_at)
    );
 }
 

--- a/frontend/src/pulldasher/sort.ts
+++ b/frontend/src/pulldasher/sort.ts
@@ -32,6 +32,8 @@ export function signatureCompare(a: Signature, b: Signature) {
    return (
       // Active before inactive
       b.data.active - a.data.active ||
+      // My sigs before others
+      compareBool(a.data.user.login == getUser(), b.data.user.login == getUser()) ||
       // Older before newer
       a.data.created_at.localeCompare(b.data.created_at)
    );

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -149,6 +149,20 @@ export const theme = extendTheme({
             },
          }
       },
+      SignatureListItem: {
+         baseStyle: {
+            display: "block",
+            color: "var(--build-status-text)",
+            borderBottom: "1px solid var(--build-status-link-divider)",
+            "&:last-child": {
+               borderBottom: "none",
+            },
+            padding: "5px",
+            "&:hover": {
+               "background": "var(--build-status-hover)",
+            }
+         },
+      },
       PullFlag: {
          baseStyle: {
             py: "5px",

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -108,7 +108,7 @@ export const theme = extendTheme({
                marginLeft: "10px",
             },
             "&:hover": {
-               "background": "rgb(128,128,128,0.1)",
+               "background": "var(--build-status-hover)",
             }
          },
          variants: {

--- a/frontend/src/theme/day_theme.less
+++ b/frontend/src/theme/day_theme.less
@@ -151,10 +151,6 @@ body[data-theme="day_theme"] {
     --signature-invalid: @yellow;
     --signature-invalid-mine: @red;
 
-    // On hover signoffs
-    --signature-separator-border: @grey;
-    --signature-separator-background: @black;
-
     --copy-branch: darken(@grey, 25%);
     --copy-branch-hover: darken(@blue, 10%);
 

--- a/frontend/src/theme/day_theme.less
+++ b/frontend/src/theme/day_theme.less
@@ -88,7 +88,8 @@ body[data-theme="day_theme"] {
     --build-state-failure: @yellow;
     --build-state-error:   @red;
     --build-state-success: @green;
-    --build-status-link-divider: @grey;
+    --build-status-link-divider: rgba(128,128,128,0.2);
+    --build-status-hover: var(--build-status-link-divider);
     --build-status-text: @dark-grey;
 
     --tag-default-border: darken(@light-grey, 10%);

--- a/frontend/src/theme/night_theme.less
+++ b/frontend/src/theme/night_theme.less
@@ -152,10 +152,6 @@ body[data-theme="night_theme"] {
     --signature-invalid: @yellow;
     --signature-invalid-mine: @red;
 
-    // On hover signoffs
-    --signature-separator-border: @grey;
-    --signature-separator-background: @black;
-
     --refresh: darken(@grey, 15%);
     --refresh-background: @steel;
     --refresh-hover: @blue;

--- a/frontend/src/theme/night_theme.less
+++ b/frontend/src/theme/night_theme.less
@@ -93,7 +93,8 @@ body[data-theme="night_theme"] {
     --build-state-failure: @yellow;
     --build-state-error:   @red;
     --build-state-success: @green;
-    --build-status-link-divider: @grey;
+    --build-status-link-divider: rgba(128,128,128,0.2);
+    --build-status-hover: var(--build-status-link-divider);
     --build-status-text: @light-grey;
 
     --tag-default-border: @dark-grey;

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -6,10 +6,10 @@ export function actionMessage(action: string, date: DateString | null, user: str
     `${action} by ${user}`;
 }
 
-function formatDate(date: DateString) {
-   return (new Date(date)).toLocaleDateString('en-us', {
-      'month': 'short',
-      'day': 'numeric'
+export function formatDate(date: DateString) {
+   return (new Date(date)).toLocaleDateString([], {
+      month: 'short',
+      day: 'numeric',
    });
 }
 

--- a/frontend/test/named-pulls.ts
+++ b/frontend/test/named-pulls.ts
@@ -98,6 +98,56 @@ export const Signatures = <PullData[]> [
    }),
 ];
 
+export const ManySignatures = <PullData[]> [
+   pullData({
+      title: "1 out-of-date QA by me, 1 active and 3 out of date CRs, with one by me",
+      status: {
+         allQA: [sig(SignatureType.QA, false, "user1")],
+         allCR: [
+            sig(SignatureType.CR, true, "user8"),
+            sig(SignatureType.CR, false, "user9"),
+            sig(SignatureType.CR, false, "user10"),
+            sig(SignatureType.CR, false, getUser()),
+         ],
+      },
+   }),
+   pullData({
+      title: "3 active QAs, 5 active CRs and 5 out of date CRs by different users",
+      status: {
+         allQA: [
+            sig(SignatureType.QA, true, "user8"),
+            sig(SignatureType.QA, true, "user9"),
+            sig(SignatureType.QA, true, "user10"),
+         ],
+         allCR: [
+            sig(SignatureType.CR, false, "user1"),
+            sig(SignatureType.CR, false, "user2"),
+            sig(SignatureType.CR, false, "user3"),
+            sig(SignatureType.CR, false, "user4"),
+            sig(SignatureType.CR, false, "user5"),
+            sig(SignatureType.CR, true, "user6"),
+            sig(SignatureType.CR, true, "user7"),
+            sig(SignatureType.CR, true, "user8"),
+            sig(SignatureType.CR, true, "user9"),
+            sig(SignatureType.CR, true, "user10"),
+         ],
+      },
+   }),
+   pullData({
+      title: "1 active CR and 5 out of date CRs by different users",
+      status: {
+         allQA: [],
+         allCR: [
+            sig(SignatureType.CR, false, "user1"),
+            sig(SignatureType.CR, false, "user2"),
+            sig(SignatureType.CR, false, "user3"),
+            sig(SignatureType.CR, false, "user4"),
+            sig(SignatureType.CR, false, "user5"),
+            sig(SignatureType.CR, true, "user6"),
+         ],
+      },
+   }),
+];
 const activeCR2 = sig(SignatureType.CR, true);
 const activeQA2 = sig(SignatureType.QA, true);
 export const FulfilledRequirements = <PullData[]> [

--- a/frontend/test/pull-card-demo.tsx
+++ b/frontend/test/pull-card-demo.tsx
@@ -7,6 +7,7 @@ import {
    PartialRequirements,
    FulfilledRequirements,
    Signatures,
+   ManySignatures,
    FewStatuses,
    RequiredStatuses,
    ManyStatuses,
@@ -31,6 +32,7 @@ function PullCardDemo() {
          <Row title="Partial Requirements" pullDatas={PartialRequirements}/>
          <Row title="Fulfilled Requirements" pullDatas={FulfilledRequirements}/>
          <Row title="Signatures in Different states" pullDatas={Signatures}/>
+         <Row title="Many Signatures" pullDatas={ManySignatures}/>
          <Row title="Few Commit Statuses" pullDatas={FewStatuses}/>
          <Row title="Repo with Required Commit Status 'unit-tests'" pullDatas={RequiredStatuses}/>
          <Row title="Many Commit Statuses" pullDatas={ManyStatuses}/>


### PR DESCRIPTION
Closes #298 
Connect #284

Changes the display of signatures, never showing more than one bubble per required CR / QA. Much more details are shown in a popup that's triggered on click.
![image](https://user-images.githubusercontent.com/26855/170330573-82483815-fb65-4d38-958b-a99b37fc509f.png)

![image](https://user-images.githubusercontent.com/26855/170330936-04b7f6bb-dbe4-48e8-871c-511e7f5c8a11.png)
