### PR TITLE
Do not invalidate signatures on clean merge

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -154,6 +154,8 @@ module.exports = {
       }
    ],
 
+   // Don't invalidate signatures on a clean merge commit.
+   ignoreCleanMerge: true,
    // Where to store the PID of the pulldasher process when run.
    pidFile: "/var/run/pulldasher.pid",
    // Setting this to true prints more debugging information.

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -483,5 +483,5 @@ function filterOutPulls(issues) {
  * Extract the commit date from commit object
 */
 function getCommitDate(commit) {
-   return commit.commit.committer.date;
+   return new Date(commit.commit.committer.date);
 }

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -172,11 +172,11 @@ module.exports = {
          }, commentSignatures);
 
          // Signoffs from before the most recent commit are no longer active.
-         var latestCommitDate = new Date(latestCommit.commit.committer.date);
+         var latestDate = new Date(latestCommit ? latestCommit.commit.committer.date : githubPull.created_at);
          signatures.forEach(function(signature) {
             if ((signature.data.type === 'CR' ||
              signature.data.type === 'QA') &&
-             new Date(signature.data.created_at) < latestCommitDate) {
+             new Date(signature.data.created_at) < latestDate) {
                signature.data.active = false;
             }
          });

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -128,7 +128,7 @@ module.exports = {
 
       var reviewComments = getPullReviewComments(repo, githubPull.number);
       var comments = getIssueComments(repo, githubPull.number);
-      var headCommit = getCommit(repo, githubPull.head.sha);
+      var latestCommit = getLatestCommit(repo, githubPull.number, githubPull.head.sha);
       var commitStatuses = getCommitStatuses(repo, githubPull.head.sha);
       var commitChecks = getCommitChecks(repo, githubPull.head.sha);
       var events = getIssueEvents(repo, githubPull.number);
@@ -140,7 +140,7 @@ module.exports = {
       // a promise that resolves to a Pull.
       return Promise.all([reviewComments,
                           comments,
-                          headCommit,
+                          latestCommit,
                           commitStatuses,
                           commitChecks,
                           events,
@@ -149,7 +149,7 @@ module.exports = {
        .then(function(results) {
          var reviewComments = results[0],
              comments       = results[1],
-             headCommit     = results[2],
+             latestCommit   = results[2],
              commitStatuses = results[3],
              commitChecks   = results[4],
              events         = results[5],
@@ -172,11 +172,11 @@ module.exports = {
          }, commentSignatures);
 
          // Signoffs from before the most recent commit are no longer active.
-         var headCommitDate = new Date(headCommit.commit.committer.date);
+         var latestCommitDate = new Date(latestCommit.commit.committer.date);
          signatures.forEach(function(signature) {
             if ((signature.data.type === 'CR' ||
              signature.data.type === 'QA') &&
-             new Date(signature.data.created_at) < headCommitDate) {
+             new Date(signature.data.created_at) < latestCommitDate) {
                signature.data.active = false;
             }
          });
@@ -409,6 +409,48 @@ function getPullReviewComments(repo, number) {
 
 function getCommit(repo, sha) {
    return githubRest.repos.getCommit(params({ ref: sha }, repo)).then(res => res.data);
+}
+
+function getCommits(repo, number) {
+   debug("Getting commits for pull #%s", number);
+   return github.paginate(githubRest.pulls.listCommits, params({ pull_number: number}, repo));
+}
+
+/**
+ * Get the lastest commit for determining signature validity
+ */
+function getLatestCommit(repo, number, head_sha) {
+   debug("Getting latest patch date for #%s", number);
+
+   // If we don't need to check for clean merges, just return the head commit
+   if (!config.ignoreCleanMerge) {
+      return getCommit(repo, head_sha);
+   }
+
+   // We only need to fetch the changes for merge commits
+   const shouldFetchFiles = commit => commit.parents.length > 1;
+   // Merge commits with no file changes are clean
+   const shouldIgnore = commit => shouldFetchFiles(commit) && !commit.files.length;
+
+   return getCommits(repo, number)
+      .then(commits => {
+         return Promise.all(commits.map(commit => {
+            if (shouldFetchFiles(commit)) {
+               return getCommit(repo, commit.sha);
+            } else {
+               return Promise.resolve(commit);
+            }
+         }))
+      })
+      .then(expandedCommits => {
+         // Reduce to the latest commit
+         return expandedCommits.reduce(function(latestCommit, commit) {
+            if (shouldIgnore(commit)) {
+               return latestCommit;
+            }
+            return commit;
+         });
+      });
 }
 
 function getCommitStatuses(repo, ref) {

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -172,7 +172,7 @@ module.exports = {
          }, commentSignatures);
 
          // Signoffs from before the most recent commit are no longer active.
-         var latestDate = new Date(latestCommit ? latestCommit.commit.committer.date : githubPull.created_at);
+         var latestDate = new Date(latestCommit ? getCommitDate(latestCommit) : githubPull.created_at);
          signatures.forEach(function(signature) {
             if ((signature.data.type === 'CR' ||
              signature.data.type === 'QA') &&
@@ -445,9 +445,10 @@ function getLatestCommit(repo, number, head_sha) {
       .then(expandedCommits => {
          // Reduce to the latest commit
          return expandedCommits.reduce(function(latestCommit, commit) {
-            if (shouldIgnore(commit)) {
+            if (shouldIgnore(commit) || getCommitDate(commit) < getCommitDate(latestCommit)) {
                return latestCommit;
             }
+
             return commit;
          });
       });
@@ -476,4 +477,11 @@ function filterOutPulls(issues) {
                      issue => !issue.pull_request || !issue.pull_request.url);
    debug("Filtered down to %s issues", issues.length);
    return issues;
+}
+
+/**
+ * Extract the commit date from commit object
+*/
+function getCommitDate(commit) {
+   return commit.commit.committer.date;
 }


### PR DESCRIPTION
This was some functionality that we needed for our instance of pulldasher, so I added a quick solution.

One peculiarity is, since selecting the current changes during a conflict is an empty change, some conflicts resolutions are considered clean.

Thought I would open a pull here in case it could be useful for solving https://github.com/iFixit/pulldasher/issues/239 on your end.

<details>
<summary> With `ignoreCleanMerge` set to `true` </summary>

![true](https://user-images.githubusercontent.com/26757800/170821407-e174d008-d752-4b31-a8e7-4add6f7af1bb.png)
</details>

<details>
<summary> With `ignoreCleanMerge` set to `false` </summary>

![false](https://user-images.githubusercontent.com/26757800/170821404-d07756cb-897c-4fb8-bc78-3ba2705e43c5.png)
</details>

Ref: https://github.com/iFixit/pulldasher/issues/239