### PR TITLE
Mobile support: MVP

### DIFF
--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -2,6 +2,7 @@ import { FilterMenu } from './filter-menu';
 import { usePulls, useAllOpenPulls, useSetFilter } from './pulldasher/pulls-context';
 import { Pull } from './pull';
 import {
+   chakra,
    useColorMode,
    Button,
    HStack,
@@ -27,6 +28,8 @@ export function Navbar(props: BoxProps) {
    const setPullFilter = useSetFilter();
    const {toggleColorMode} = useColorMode();
    const [showCryo, setShowCryo] = useBoolUrlState('cryo', false);
+   const hideBelowMedium = ['none', 'none', 'block'];
+   const hideBelowLarge = ['none', 'none', 'none', 'block'];
 
    const toggleShowCryo = useCallback(() => setShowCryo(!showCryo), [showCryo]);
    useEffect(() => setPullFilter('cryo', showCryo ? null : isPullCryo), [showCryo]);
@@ -35,13 +38,14 @@ export function Navbar(props: BoxProps) {
       <Center py={2} bgColor="var(--header-background)" color="var(--brand-color)" {...props}>
          <Flex px="var(--body-gutter)" maxW="100%" w="var(--body-max-width)" gap="var(--body-gutter)" justify="space-between">
             <HStack alignSelf="center" flexGrow={1} flexBasis={sideWidth} spacing="2">
-               <Box p="0 15px 0 0" fontSize="16px">
+               <Box display={hideBelowLarge} p="1 15px 0 0" fontSize="16px">
                   <ConnectionStateIndicator/>
                </Box>
-               <span title={`Shown: ${pulls.size} Total: ${allOpenPulls.length}`}>
+               <chakra.span display={hideBelowLarge} title={`Shown: ${pulls.size} Total: ${allOpenPulls.length}`}>
                   open: {pulls.size}
-               </span>
+               </chakra.span>
                <Button
+                  display={hideBelowMedium}
                   size="sm"
                   title="Show pulls with label Cryogenic Storage"
                   colorScheme="blue"
@@ -50,6 +54,7 @@ export function Navbar(props: BoxProps) {
                   <FontAwesomeIcon icon={faSnowflake}/>
                </Button>
                <Button
+                  display={hideBelowMedium}
                   size="sm"
                   title="Dark Mode"
                   colorScheme="blue"

--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -20,7 +20,7 @@ export const Pulldasher: React.FC = function() {
       <Box maxW="var(--body-max-width)" m="auto" px="var(--body-gutter)">
          <VStack spacing="var(--body-gutter)">
             <LeaderList title="CR Leaders" leaders={leadersCR}/>
-            <SimpleGrid columns={3} spacing="var(--body-gutter)" w="100%">
+            <SimpleGrid minChildWidth='300px' spacing="var(--body-gutter)" w="100%">
                <Box>
                   <Column id="ci" title="CI Blocked" variant="ciBlocked" pulls={pullsCIBlocked}/>
                </Box>


### PR DESCRIPTION
Add just a dash of mobile support:

* Set a min-width on the columns so the format goes to 2-wide, then 1-wide as it gets smaller
* Hide some header widgets as browser size gets smaller so it's not too crowded

This gets us most of the way there without too much effort.

Connect #325 