### PR TITLE
GitHub Actions: Mark skipped jobs as success

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,6 +66,7 @@ module.exports = {
          case 'queued':
             return 'pending';
          case 'success':
+         case 'skipped':
             return 'success';
          case 'failure':
             return 'failure';


### PR DESCRIPTION
We sometimes skip jobs and want them to not be shown as errors in pulldasher. Let's map `skipped` -> `success` so they don't get stuck in ci_blocked.

Ref: https://ifixit.slack.com/archives/C01DBJK0H7U/p1661213572318169

Closes: https://github.com/iFixit/ifixit/issues/44378