### PR TITLE
Reviews: Treat reviews as CR status

### DIFF
--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -22,7 +22,7 @@ const github = new MyOctokit({
         github.log.warn(
           `Request quota exhausted for request ${options.method} ${options.url}`
         );
-  
+
         // Retry five times after hitting a rate limit error, then give up
         if (options.request.retryCount <= 5) {
           github.log.debug(`Retrying after ${retryAfter} seconds!`);
@@ -36,7 +36,7 @@ const github = new MyOctokit({
         );
       },
     }
-}); 
+});
 
 const githubRest = github.rest;
 

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -164,22 +164,22 @@ module.exports = {
             return sigs.concat(commentSigs);
          }, []);
 
-         var signatures = reviews.reduce(function(sigs, review) {
-            var reviewSigs = Signature.parseReview(
-             review, repo, githubPull.number);
-
-            return sigs.concat(reviewSigs);
-         }, commentSignatures);
-
          // Signoffs from before the most recent commit are no longer active.
          var headCommitDate = new Date(headCommit.commit.committer.date);
-         signatures.forEach(function(signature) {
+         commentSignatures.forEach(function(signature) {
             if ((signature.data.type === 'CR' ||
              signature.data.type === 'QA') &&
              new Date(signature.data.created_at) < headCommitDate) {
                signature.data.active = false;
             }
          });
+
+         var signatures = reviews.reduce(function(sigs, review) {
+            var reviewSigs = Signature.parseReview(
+             review, repo, githubPull.number);
+
+            return sigs.concat(reviewSigs);
+         }, commentSignatures);
 
          // Array of Comment objects.
          comments = comments.map(function(commentData) {

--- a/models/signature.js
+++ b/models/signature.js
@@ -95,7 +95,7 @@ function parseReviewSignature(data) {
          active: true,
          comment_id: data.id
       }));
-   };
+   }
 
    if (data.state === 'DISMISSED' || data.state === 'PENDING') {
       signatures.push(new Signature({

--- a/models/signature.js
+++ b/models/signature.js
@@ -80,54 +80,31 @@ Signature.parseReview = function parseReview(review, repoFullName, pullNumber) {
 };
 
 function parseReviewSignature(data) {
-   let signatures = [];
+   let signatureData = {
+      repo: data.repo,
+      number: data.number,
+      user: {
+         id:    getUserid(data.user),
+         login: getLogin(data.user)
+      },
+      created_at: data.created_at,
+      comment_id: data.id
+   };
 
    if (data.state === 'APPROVED') {
-      signatures.push(new Signature({
-         repo: data.repo,
-         number: data.number,
-         user: {
-            id:    getUserid(data.user),
-            login: getLogin(data.user)
-         },
-         type: 'CR',
-         created_at: data.created_at,
-         active: true,
-         comment_id: data.id
-      }));
+      signatureData.active = true;
+      signatureData.type = 'CR';
+   } else if (data.state === 'DISMISSED' || data.state === 'PENDING') {
+      signatureData.active = false;
+      signatureData.type = 'CR';
+   } else if (data.state === 'CHANGES_REQUESTED') {
+      signatureData.active = true;
+      signatureData.type = 'dev_block';
+   } else {
+      return [];
    }
 
-   if (data.state === 'DISMISSED' || data.state === 'PENDING') {
-      signatures.push(new Signature({
-         repo: data.repo,
-         number: data.number,
-         user: {
-            id:    getUserid(data.user),
-            login: getLogin(data.user)
-         },
-         type: 'CR',
-         created_at: data.created_at,
-         active: false,
-         comment_id: data.id
-      }));
-   }
-
-   if (data.state === 'CHANGES_REQUESTED') {
-      signatures.push(new Signature({
-         repo: data.repo,
-         number: data.number,
-         user: {
-            id:    getUserid(data.user),
-            login: getLogin(data.user)
-         },
-         type: 'dev_block',
-         created_at: data.created_at,
-         active: true,
-         comment_id: data.id
-      }));
-   }
-
-   return signatures;
+   return [new Signature(signatureData)];
 }
 
 /**


### PR DESCRIPTION
Reviews are awesome in GH. They have a natively defined state in GH which
we can read in pulldasher. Let's pull that information automatically
from the Review.

The old `CR :emoji` should still work on regular comments. We plan to
phase this out if we like working strictly with Reviews for the CR
status.

Note: We now don't listen to any other signatures on the Review comment.

QA:
--
Check out this branch on pulldasher-dev and play around with it. Make sure
`CR :emoji:` get invalidated when a new commit is pushed. Make sure
Reviews are invalidated when the Review is dismissed.

Connects: https://github.com/iFixit/ifixit/issues/44538
Connects: https://github.com/iFixit/ifixit/discussions/44648

cc @danielbeardsley 