### PR TITLE
GitHub webhooks: be tolerant

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ var config = require('./lib/config-loader'),
 
 var app = express();
 var httpServer = require('http').createServer(app);
+const maxPostSize = 1024*1024;
 
 app.set('view engine', 'html');
 
@@ -23,8 +24,8 @@ app.set('view engine', 'html');
  * Middleware
  */
 app.use("/public", express.static(__dirname + '/public'));
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ limit: maxPostSize, extended: false }));
+app.use(bodyParser.json({limit: maxPostSize}));
 app.use(expressSession({
    secret: config.session.secret,
    resave: false,

--- a/models/pull.js
+++ b/models/pull.js
@@ -155,6 +155,10 @@ Pull.prototype.getStatus = function getStatus() {
 Pull.parseBody = function(body) {
    var bodyTags = [];
 
+   if (!body) {
+      return [];
+   }
+
    config.body_tags.forEach(function(tag) {
       var matches = body.match(tag.regex);
 


### PR DESCRIPTION
* Gracefully deal with null `pull.body`
* Support parsing larger webhook bodies (we've see pretty big ones)

qa_req 0 - I think there's not much to QA here without actually trying it