### PR TITLE
Closed pulls: Add a new column to show recently closed or merged pulls

### DIFF
--- a/frontend/dummy-pulls.json
+++ b/frontend/dummy-pulls.json
@@ -7854,7 +7854,7 @@
     "created_at": "2020-12-23T01:36:52.000Z",
     "updated_at": "2020-12-23T01:37:27.000Z",
     "merged_at": null,
-    "closed_at":  "2020-12-25T01:37:27.000Z",
+    "closed_at":  "2020-12-25T01:39:27.000Z",
     "difficulty": null,
     "milestone": {
       "title": null,

--- a/frontend/dummy-pulls.json
+++ b/frontend/dummy-pulls.json
@@ -7844,5 +7844,117 @@
       "ready": false
     },
     "labels": []
+  },
+  {
+    "repo": "iFixit/server-templates",
+    "number": 2986,
+    "state": "closed",
+    "title": "Akeneo: Finish the migration",
+    "body": "pull request dummy body",
+    "created_at": "2020-12-23T01:36:52.000Z",
+    "updated_at": "2020-12-23T01:37:27.000Z",
+    "merged_at": null,
+    "closed_at":  "2020-12-25T01:37:27.000Z",
+    "difficulty": null,
+    "milestone": {
+      "title": null,
+      "due_on": null
+    },
+    "head": {
+      "ref": "akeneo-finish-the-thing",
+      "sha": "a728494a733bbed5748efbe94cbab8dc8bb0657c",
+      "repo": {
+        "owner": {
+          "login": "iFixit"
+        }
+      }
+    },
+    "base": {
+      "ref": "master"
+    },
+    "user": {
+      "login": "danielbeardsley"
+    },
+    "cr_req": 2,
+    "qa_req": 1,
+    "status": {
+      "qa_req": 1,
+      "cr_req": 2,
+      "QA": [],
+      "CR": [],
+      "allQA": [],
+      "allCR": [],
+      "dev_block": [],
+      "deploy_block": [],
+      "commit_statuses": [
+        {
+          "data": {
+            "sha": "a728494a733bbed5748efbe94cbab8dc8bb0657c",
+            "target_url": "https://wwww.example.com",
+            "description": "Build success",
+            "state": "success",
+            "context": "phpunit"
+          }
+        }
+      ],
+      "ready": false
+    },
+    "labels": []
+  },
+  {
+    "repo": "iFixit/ifixit",
+    "number": 38986,
+    "state": "closed",
+    "title": "Routing: tripple the bypass udocles",
+    "body": "pull request dummy body",
+    "created_at": "2020-12-23T01:36:52.000Z",
+    "updated_at": "2020-12-23T01:37:27.000Z",
+    "closed_at":  "2020-12-25T01:37:27.000Z",
+    "merged_at":  "2020-12-25T01:37:27.000Z",
+    "difficulty": null,
+    "milestone": {
+      "title": null,
+      "due_on": null
+    },
+    "head": {
+      "ref": "akeneo-finish-the-thing",
+      "sha": "a728494a733bbed5748efbe94cbab8dc8bb0657c",
+      "repo": {
+        "owner": {
+          "login": "iFixit"
+        }
+      }
+    },
+    "base": {
+      "ref": "master"
+    },
+    "user": {
+      "login": "notme"
+    },
+    "cr_req": 2,
+    "qa_req": 1,
+    "status": {
+      "qa_req": 1,
+      "cr_req": 2,
+      "QA": [],
+      "CR": [],
+      "allQA": [],
+      "allCR": [],
+      "dev_block": [],
+      "deploy_block": [],
+      "commit_statuses": [
+        {
+          "data": {
+            "sha": "a728494a733bbed5748efbe94cbab8dc8bb0657c",
+            "target_url": "https://wwww.example.com",
+            "description": "Build success",
+            "state": "success",
+            "context": "phpunit"
+          }
+        }
+      ],
+      "ready": false
+    },
+    "labels": []
   }
 ]

--- a/frontend/src/closed-pulls.tsx
+++ b/frontend/src/closed-pulls.tsx
@@ -7,7 +7,13 @@ export function ClosedPulls({onClickClose}: {onClickClose: () => void}) {
    const closedPulls: Pull[] = useFilteredPulls().filter(pull => pull.closed_at);
    const styles = useStyleConfig('Column', {variant: "closed"});
    return (
-      <Box __css={styles} position="absolute" right="0" top="70" bottom="0" width="300px" boxShadow="0px 0px 10px 0px #00000020">
+      <Box __css={styles}
+         position="absolute"
+         right="0"
+         top="70"
+         bottom="0"
+         width="300px"
+         boxShadow="0px 0px 10px 0px #00000020">
          <Flex className="column_header" onClick={onClickClose}>
             <Box p={3} pl={4}>Recently Closed Pulls</Box>
             <Spacer/>

--- a/frontend/src/closed-pulls.tsx
+++ b/frontend/src/closed-pulls.tsx
@@ -1,10 +1,17 @@
-import { useFilteredPulls, useAllOpenPulls } from './pulldasher/pulls-context';
-import { Pull } from './pull';
-import { useStyleConfig, Flex, Spacer, Box } from "@chakra-ui/react"
+import { useFilteredPulls, useAllPulls } from './pulldasher/pulls-context';
+import { useStyleConfig, Flex, Spacer, Box, Button } from "@chakra-ui/react"
 import { ClosedPullCard } from "./pull-card";
+import { useBoolUrlState } from "./use-url-state";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFilter } from '@fortawesome/free-solid-svg-icons'
 
 export function ClosedPulls({onClickClose}: {onClickClose: () => void}) {
-   const closedPulls: Pull[] = useFilteredPulls().filter(pull => pull.closed_at);
+   const [showUnfilteredPulls, toggleShowUnfilteredPulls] = useBoolUrlState("uncl", false);
+   const allPulls = useAllPulls();
+   const filteredPulls = useFilteredPulls();
+   const pullsToCareAbout = showUnfilteredPulls ? allPulls : filteredPulls;
+   const closedPulls = pullsToCareAbout.filter(pull => pull.closed_at);
+
    const styles = useStyleConfig('Column', {variant: "closed"});
    return (
       <Box __css={styles}
@@ -15,7 +22,19 @@ export function ClosedPulls({onClickClose}: {onClickClose: () => void}) {
          width="300px"
          boxShadow="0px 0px 10px 0px #00000020">
          <Flex className="column_header" onClick={onClickClose}>
-            <Box p={3} pl={4}>Recently Closed Pulls</Box>
+            <Box p={3} pl={4}>Recently Closed Pulls
+               <Button
+                  ml={2}
+                  my={-4}
+                  p={1}
+                  size="sm"
+                  title="Filter Pulls"
+                  colorScheme="blue"
+                  variant={showUnfilteredPulls ? 'ghost' : 'solid'}
+                  onClick={(e) => {e.stopPropagation(); toggleShowUnfilteredPulls()}}>
+                  <FontAwesomeIcon icon={faFilter}/>
+               </Button>
+            </Box>
             <Spacer/>
             <Box className="pull_count" p={3}>{closedPulls.length}</Box>
          </Flex>

--- a/frontend/src/closed-pulls.tsx
+++ b/frontend/src/closed-pulls.tsx
@@ -1,10 +1,10 @@
-import { useAllPulls, useAllOpenPulls } from './pulldasher/pulls-context';
+import { useFilteredPulls, useAllOpenPulls } from './pulldasher/pulls-context';
 import { Pull } from './pull';
 import { useStyleConfig, Flex, Spacer, Box } from "@chakra-ui/react"
 import { ClosedPullCard } from "./pull-card";
 
 export function ClosedPulls({onClickClose}: {onClickClose: () => void}) {
-   const closedPulls: Pull[] = useAllPulls().filter(pull => pull.closed_at);
+   const closedPulls: Pull[] = useFilteredPulls().filter(pull => pull.closed_at);
    const styles = useStyleConfig('Column', {variant: "closed"});
    return (
       <Box __css={styles} position="absolute" right="0" top="70" bottom="0" width="300px" boxShadow="0px 0px 10px 0px #00000020">

--- a/frontend/src/closed-pulls.tsx
+++ b/frontend/src/closed-pulls.tsx
@@ -1,0 +1,22 @@
+import { useAllPulls, useAllOpenPulls } from './pulldasher/pulls-context';
+import { Pull } from './pull';
+import { useStyleConfig, Flex, Spacer, Box } from "@chakra-ui/react"
+import { ClosedPullCard } from "./pull-card";
+
+export function ClosedPulls({onClickClose}: {onClickClose: () => void}) {
+   const closedPulls: Pull[] = useAllPulls().filter(pull => pull.closed_at);
+   const styles = useStyleConfig('Column', {variant: "closed"});
+   return (
+      <Box __css={styles} position="absolute" right="0" top="70" bottom="0" width="300px" boxShadow="0px 0px 10px 0px #00000020">
+         <Flex className="column_header" onClick={onClickClose}>
+            <Box p={3} pl={4}>Recently Closed Pulls</Box>
+            <Spacer/>
+            <Box className="pull_count" p={3}>{closedPulls.length}</Box>
+         </Flex>
+         {closedPulls.map(pull =>
+            <ClosedPullCard key={Math.random()} pull={pull} show={true}/>
+         )}
+      </Box>
+   );
+}
+

--- a/frontend/src/closed-pulls.tsx
+++ b/frontend/src/closed-pulls.tsx
@@ -7,7 +7,9 @@ import { useMemo } from "react";
 export function ClosedPulls({onClickClose}: {onClickClose: () => void}) {
    const filteredPulls = useFilteredPulls();
    const closedPulls = useMemo(() => {
-      return filteredPulls.filter(pull => pull.closed_at);
+      const pulls = filteredPulls.filter(pull => pull.closed_at);
+      pulls.sort(closedAtCompare);
+      return pulls;
    }, [filteredPulls]);
 
    const styles = useStyleConfig('Column', {variant: "closed"});

--- a/frontend/src/closed-pulls.tsx
+++ b/frontend/src/closed-pulls.tsx
@@ -20,7 +20,7 @@ export function ClosedPulls({onClickClose}: {onClickClose: () => void}) {
             <Box className="pull_count" p={3}>{closedPulls.length}</Box>
          </Flex>
          {closedPulls.map(pull =>
-            <ClosedPullCard key={Math.random()} pull={pull} show={true}/>
+            <ClosedPullCard key={pull.getKey()} pull={pull} show={true}/>
          )}
       </Box>
    );

--- a/frontend/src/closed-pulls.tsx
+++ b/frontend/src/closed-pulls.tsx
@@ -1,16 +1,14 @@
-import { useFilteredPulls, useAllPulls } from './pulldasher/pulls-context';
-import { useStyleConfig, Flex, Spacer, Box, Button } from "@chakra-ui/react"
+import { useFilteredPulls } from './pulldasher/pulls-context';
+import { useStyleConfig, Flex, Spacer, Box } from "@chakra-ui/react"
 import { ClosedPullCard } from "./pull-card";
-import { useBoolUrlState } from "./use-url-state";
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faFilter } from '@fortawesome/free-solid-svg-icons'
+import { closedAtCompare } from './pulldasher/sort';
+import { useMemo } from "react";
 
 export function ClosedPulls({onClickClose}: {onClickClose: () => void}) {
-   const [showUnfilteredPulls, toggleShowUnfilteredPulls] = useBoolUrlState("uncl", false);
-   const allPulls = useAllPulls();
    const filteredPulls = useFilteredPulls();
-   const pullsToCareAbout = showUnfilteredPulls ? allPulls : filteredPulls;
-   const closedPulls = pullsToCareAbout.filter(pull => pull.closed_at);
+   const closedPulls = useMemo(() => {
+      return filteredPulls.filter(pull => pull.closed_at);
+   }, [filteredPulls]);
 
    const styles = useStyleConfig('Column', {variant: "closed"});
    return (
@@ -22,19 +20,7 @@ export function ClosedPulls({onClickClose}: {onClickClose: () => void}) {
          width="300px"
          boxShadow="0px 0px 10px 0px #00000020">
          <Flex className="column_header" onClick={onClickClose}>
-            <Box p={3} pl={4}>Recently Closed Pulls
-               <Button
-                  ml={2}
-                  my={-4}
-                  p={1}
-                  size="sm"
-                  title="Filter Pulls"
-                  colorScheme="blue"
-                  variant={showUnfilteredPulls ? 'ghost' : 'solid'}
-                  onClick={(e) => {e.stopPropagation(); toggleShowUnfilteredPulls()}}>
-                  <FontAwesomeIcon icon={faFilter}/>
-               </Button>
-            </Box>
+            <Box p={3} pl={4}>Recently Closed Pulls</Box>
             <Spacer/>
             <Box className="pull_count" p={3}>{closedPulls.length}</Box>
          </Flex>

--- a/frontend/src/column.tsx
+++ b/frontend/src/column.tsx
@@ -1,7 +1,7 @@
 import { Pull } from './pull';
 import { PullCard } from './pull-card';
 import { useBoolUrlState } from './use-url-state';
-import { usePulls } from './pulldasher/pulls-context';
+import { useFilteredOpenPulls } from './pulldasher/pulls-context';
 import { Box, Flex, Spacer, useStyleConfig } from "@chakra-ui/react"
 
 interface ColumnProps {
@@ -12,7 +12,7 @@ interface ColumnProps {
 }
 
 export function Column(props: ColumnProps) {
-   const pullsToShow = usePulls();
+   const pullsToShow = useFilteredOpenPulls();
    const [open, toggleOpen] = useBoolUrlState(props.id, true);
    const styles = useStyleConfig('Column', {variant: props.variant});
    return (

--- a/frontend/src/column.tsx
+++ b/frontend/src/column.tsx
@@ -13,11 +13,11 @@ interface ColumnProps {
 
 export function Column(props: ColumnProps) {
    const pullsToShow = usePulls();
-   const [open, setOpen] = useBoolUrlState(props.id, true);
+   const [open, toggleOpen] = useBoolUrlState(props.id, true);
    const styles = useStyleConfig('Column', {variant: props.variant});
    return (
       <Box __css={styles} overflow="hidden">
-         <Flex className="column_header" onClick={() => setOpen(!open)}>
+         <Flex className="column_header" onClick={toggleOpen}>
             <Box p={3} pl={4}>{props.title}</Box>
             <Spacer/>
             <Box className="pull_count" p={3}>{countPulls(props.pulls, pullsToShow)}</Box>

--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -36,7 +36,6 @@ export function Navbar(props: NavBarProps) {
    const {toggleShowClosedPulls, showClosedPulls, ...boxProps} = props;
    const pulls: Set<Pull> = useFilteredOpenPulls();
    const allOpenPulls: Pull[] = useAllOpenPulls();
-   const mergedPulls: Pull[] = Array.from(useAllPulls()).filter(pull => pull.merged_at);
    const setPullFilter = useSetFilter();
    const {toggleColorMode} = useColorMode();
    const [showCryo, toggleShowCryo] = useBoolUrlState('cryo', false);

--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -39,15 +39,12 @@ export function Navbar(props: NavBarProps) {
    const mergedPulls: Pull[] = Array.from(useAllPulls()).filter(pull => pull.merged_at);
    const setPullFilter = useSetFilter();
    const {toggleColorMode} = useColorMode();
-   const [showCryo, setShowCryo] = useBoolUrlState('cryo', false);
-   const [showExtBlocked, setShowExtBlocked] = useBoolUrlState('external_block', true);
+   const [showCryo, toggleShowCryo] = useBoolUrlState('cryo', false);
+   const [showExtBlocked, toggleShowExtBlocked] = useBoolUrlState('external_block', true);
    const hideBelowMedium = ['none', 'none', 'block'];
    const hideBelowLarge = ['none', 'none', 'none', 'block'];
 
-   const toggleShowCryo = useCallback(() => setShowCryo(!showCryo), [showCryo]);
    useEffect(() => setPullFilter('cryo', showCryo ? null : isNotCryogenic), [showCryo]);
-
-   const toggleShowExtBlocked = useCallback(() => setShowExtBlocked(!showExtBlocked), [showExtBlocked]);
    useEffect(() => setPullFilter('external_block', showExtBlocked ? null : isNotExternallyBlocked), [showExtBlocked]);
 
    return (

--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -22,12 +22,18 @@ import { NotificationRequest } from "./notifications"
 import { useConnectionState, ConnectionState } from "./backend/socket";
 import { useHotkeys } from 'react-hotkeys-hook';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faMoon, faWifi, faCircleNotch, faXmark, faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
+import { faMoon, faCodeMerge, faWifi, faCircleNotch, faXmark, faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
 
 // Default width of the left and right sections of the nav bar
 const sideWidth = "220px";
 
-export function Navbar(props: BoxProps) {
+type NavBarProps = BoxProps & {
+   toggleShowClosedPulls: () => void;
+   showClosedPulls: boolean;
+}
+
+export function Navbar(props: NavBarProps) {
+   const {toggleShowClosedPulls, showClosedPulls, ...boxProps} = props;
    const pulls: Set<Pull> = usePulls();
    const allOpenPulls: Pull[] = useAllOpenPulls();
    const mergedPulls: Pull[] = Array.from(useAllPulls()).filter(pull => pull.merged_at);
@@ -45,7 +51,7 @@ export function Navbar(props: BoxProps) {
    useEffect(() => setPullFilter('external_block', showExtBlocked ? null : isNotExternallyBlocked), [showExtBlocked]);
 
    return (
-      <Center py={2} bgColor="var(--header-background)" color="var(--brand-color)" {...props}>
+      <Center py={2} bgColor="var(--header-background)" color="var(--brand-color)" {...boxProps}>
          <Flex px="var(--body-gutter)" maxW="100%" w="var(--body-max-width)" gap="var(--body-gutter)" justify="space-between">
             <HStack alignSelf="center" flexGrow={1} flexBasis={sideWidth} spacing="2">
                <Box display={hideBelowLarge} p="1 15px 0 0" fontSize="16px">
@@ -62,6 +68,15 @@ export function Navbar(props: BoxProps) {
                   variant='ghost'
                   onClick={toggleColorMode}>
                   <FontAwesomeIcon icon={faMoon}/>
+               </Button>
+               <Button
+                  display={hideBelowMedium}
+                  size="sm"
+                  title="Show Recently Merged"
+                  colorScheme="blue"
+                  variant={showClosedPulls ? 'solid' : 'ghost'}
+                  onClick={toggleShowClosedPulls}>
+                  <FontAwesomeIcon icon={faCodeMerge}/>
                </Button>
                <NotificationRequest />
                <Menu closeOnSelect={false}>

--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -1,5 +1,5 @@
 import { FilterMenu } from './filter-menu';
-import { usePulls, useAllOpenPulls, useAllPulls, useSetFilter } from './pulldasher/pulls-context';
+import { useFilteredOpenPulls, useAllOpenPulls, useAllPulls, useSetFilter } from './pulldasher/pulls-context';
 import { Pull } from './pull';
 import {
    chakra,
@@ -34,7 +34,7 @@ type NavBarProps = BoxProps & {
 
 export function Navbar(props: NavBarProps) {
    const {toggleShowClosedPulls, showClosedPulls, ...boxProps} = props;
-   const pulls: Set<Pull> = usePulls();
+   const pulls: Set<Pull> = useFilteredOpenPulls();
    const allOpenPulls: Pull[] = useAllOpenPulls();
    const mergedPulls: Pull[] = Array.from(useAllPulls()).filter(pull => pull.merged_at);
    const setPullFilter = useSetFilter();

--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -1,5 +1,5 @@
 import { FilterMenu } from './filter-menu';
-import { usePulls, useAllOpenPulls, useSetFilter } from './pulldasher/pulls-context';
+import { usePulls, useAllOpenPulls, useAllPulls, useSetFilter } from './pulldasher/pulls-context';
 import { Pull } from './pull';
 import {
    chakra,
@@ -30,6 +30,7 @@ const sideWidth = "220px";
 export function Navbar(props: BoxProps) {
    const pulls: Set<Pull> = usePulls();
    const allOpenPulls: Pull[] = useAllOpenPulls();
+   const mergedPulls: Pull[] = Array.from(useAllPulls()).filter(pull => pull.merged_at);
    const setPullFilter = useSetFilter();
    const {toggleColorMode} = useColorMode();
    const [showCryo, setShowCryo] = useBoolUrlState('cryo', false);

--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -1,5 +1,5 @@
 import { FilterMenu } from './filter-menu';
-import { useFilteredOpenPulls, useAllOpenPulls, useAllPulls, useSetFilter } from './pulldasher/pulls-context';
+import { useFilteredOpenPulls, useAllOpenPulls, useSetFilter } from './pulldasher/pulls-context';
 import { Pull } from './pull';
 import {
    chakra,

--- a/frontend/src/pull-card/index.tsx
+++ b/frontend/src/pull-card/index.tsx
@@ -5,11 +5,11 @@ import { Flags } from './flags';
 import { Avatar } from './avatar';
 import { Signatures } from './signatures';
 import { CopyBranch } from './copy-branch';
-import { memo, useEffect, useRef, RefObject } from "react";
+import { memo,  useEffect, useRef, RefObject } from "react";
 import { RefreshButton } from './refresh';
 import { Flex, Box, Link, chakra } from "@chakra-ui/react"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faStar } from '@fortawesome/free-solid-svg-icons'
+import { faStar, faCodeMerge, faXmark } from '@fortawesome/free-solid-svg-icons'
 
 const Card = chakra(Flex, {
    baseStyle: {
@@ -87,6 +87,49 @@ function PullCard({pull, show}: {pull: Pull, show: boolean}) {
       </Card>
    );
 });
+
+export const ClosedPullCard = memo(
+function ClosedPullCard({pull, show}: {pull: Pull, show: boolean}) {
+   const wasMerged = !!pull.merged_at;
+   return (
+      <Card display={show ? undefined : "none"}>
+         <RefreshButton pull={pull}/>
+         <Box>
+            <Box mt={-2} ml={-2} mb={2}>
+               <chakra.span pr={2}>
+                  {wasMerged ?
+                     <FontAwesomeIcon icon={faCodeMerge} size="lg" color="var(--pull-merged)"/> :
+                     <FontAwesomeIcon icon={faXmark} color="var(--pull-closed)"/>
+                  }
+               </chakra.span>
+               <chakra.span color="var(--pull-title)">
+                  {formatDate(pull.closed_at)}
+               </chakra.span>
+            </Box>
+            <Link href={pull.getUrl()}
+               title={pull.user.login}
+               isExternal
+               textDecoration={wasMerged ? "none" : "line-through"}
+               color="var(--pull-title)">
+               {pull.isMine() ?
+               <FontAwesomeIcon icon={faStar} className="star" color="var(--user-icon)"/> :
+               <Avatar user={pull.user.login} linkToProfile/>}
+               <chakra.span fontWeight="bold">{pull.getRepoName()} #{pull.number}: </chakra.span>
+               {pull.title}
+            </Link>
+         </Box>
+      </Card>
+   );
+});
+
+const formatter = new Intl.DateTimeFormat(undefined, {
+   dateStyle: "short",
+   timeStyle: "short",
+});
+
+const formatDate = (dateStr: string|null) => {
+   return dateStr ? formatter.format(new Date(dateStr)) : null;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function highlightOnChange(ref: RefObject<HTMLElement>, dependencies: Array<any>) {

--- a/frontend/src/pull-card/index.tsx
+++ b/frontend/src/pull-card/index.tsx
@@ -5,7 +5,7 @@ import { Flags } from './flags';
 import { Avatar } from './avatar';
 import { Signatures } from './signatures';
 import { CopyBranch } from './copy-branch';
-import { memo,  useEffect, useRef, RefObject } from "react";
+import { memo, useEffect, useRef, RefObject } from "react";
 import { RefreshButton } from './refresh';
 import { Flex, Box, Link, chakra } from "@chakra-ui/react"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/frontend/src/pulldasher/filtered-pulls-state.ts
+++ b/frontend/src/pulldasher/filtered-pulls-state.ts
@@ -7,17 +7,13 @@ export type FilterFunctionSetter = (filterName:string, filter:FilterFunction|nul
 type Filters = Record<string, FilterFunction>;
 type ReturnType = [Pull[], FilterFunctionSetter];
 
-const defaultFilters = {
-   'default': (pull: Pull) => pull.isOpen()
-}
-
 /**
  * Wrapper around an array of pulls that allows multiple filters to be
  * specified.
  * setFilter(name, func) will *remove* the filter if func is null
  */
 export function useFilteredPullsState(pulls: Pull[]): ReturnType {
-   const [filters, setFilter] = useState<Filters>(defaultFilters);
+   const [filters, setFilter] = useState<Filters>({});
    const replaceNamedFilter = useCallback(
       (filterName:string, filter:FilterFunction|null) => {
          // Use the functional form of `setState()` so we can base our new

--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -1,5 +1,4 @@
 import { useAllPulls, useAllOpenPulls } from './pulls-context';
-import { Pull } from '../pull';
 import { Navbar } from '../navbar';
 import { Column } from '../column';
 import { QACompare } from './sort';

--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -1,10 +1,12 @@
 import { useAllPulls, useAllOpenPulls } from './pulls-context';
+import { Pull } from '../pull';
 import { Navbar } from '../navbar';
 import { Column } from '../column';
 import { QACompare } from './sort';
 import { LeaderList, getLeaders } from '../leader-list';
 import { useMyPullNotification, useMyReviewNotification } from "./notifications"
-import { Box, SimpleGrid, VStack } from "@chakra-ui/react"
+import { useStyleConfig, Drawer, DrawerContent, Box, SimpleGrid, VStack } from "@chakra-ui/react"
+import { ClosedPullCard } from "../pull-card";
 
 export const Pulldasher: React.FC = function() {
    const allPulls = useAllPulls();
@@ -44,6 +46,26 @@ export const Pulldasher: React.FC = function() {
                </Box>
             </SimpleGrid>
          </VStack>
+         <ClosedPulls/>
       </Box>
    </>);
+}
+
+function ClosedPulls() {
+   const closedPulls: Pull[] = Array.from(useAllPulls()).filter(pull => pull.closed_at);
+   const styles = useStyleConfig('Column', {variant: "closed"});
+   return (
+      <Drawer placement="right" isOpen={true} onClose={() => 0}>
+         <DrawerContent>
+            <Box __css={styles}>
+               <Box className="column_header">
+                  <Box p={3} pl={4}>Recently Closed Pulls</Box>
+               </Box>
+               {closedPulls.map(pull =>
+                  <ClosedPullCard key={Math.random()} pull={pull} show={true}/>
+               )}
+            </Box>
+         </DrawerContent>
+      </Drawer>
+   );
 }

--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -5,9 +5,9 @@ import { Column } from '../column';
 import { QACompare } from './sort';
 import { LeaderList, getLeaders } from '../leader-list';
 import { useMyPullNotification, useMyReviewNotification } from "./notifications"
-import { useStyleConfig, Flex, Spacer, Box, SimpleGrid, VStack } from "@chakra-ui/react"
-import { ClosedPullCard } from "../pull-card";
+import { Box, SimpleGrid, VStack } from "@chakra-ui/react"
 import { useBoolUrlState } from "../use-url-state";
+import { ClosedPulls } from '../closed-pulls';
 
 export const Pulldasher: React.FC = function() {
    const allPulls = useAllPulls();
@@ -51,21 +51,4 @@ export const Pulldasher: React.FC = function() {
          {showClosedPulls && <ClosedPulls onClickClose={toggleShowClosedPulls}/>}
       </Box>
    </>);
-}
-
-function ClosedPulls({onClickClose}: {onClickClose: () => void}) {
-   const closedPulls: Pull[] = Array.from(useAllPulls()).filter(pull => pull.closed_at);
-   const styles = useStyleConfig('Column', {variant: "closed"});
-   return (
-      <Box __css={styles} position="absolute" right="0" top="70" bottom="0" width="300px" boxShadow="0px 0px 10px 0px #00000020">
-         <Flex className="column_header" onClick={onClickClose}>
-            <Box p={3} pl={4}>Recently Closed Pulls</Box>
-            <Spacer/>
-            <Box className="pull_count" p={3}>{closedPulls.length}</Box>
-         </Flex>
-         {closedPulls.map(pull =>
-            <ClosedPullCard key={Math.random()} pull={pull} show={true}/>
-         )}
-      </Box>
-   );
 }

--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -19,8 +19,7 @@ export const Pulldasher: React.FC = function() {
    const pullsNeedingCR = pulls.filter(pull => !pull.isCrDone() && !pull.getDevBlock() && !pull.isDraft());
    const pullsNeedingQA = pulls.filter(pull => !pull.isQaDone() && !pull.getDevBlock() && !pull.isDraft() && pull.hasPassedCI());
    const leadersCR = getLeaders(allPulls, (pull) => pull.status.allCR);
-   const [showClosedPulls, setShowClosedPulls] = useBoolUrlState("closed", false);
-   const toggleShowClosedPulls = () => setShowClosedPulls(!showClosedPulls);
+   const [showClosedPulls, toggleShowClosedPulls] = useBoolUrlState("closed", false);
    useMyPullNotification(pullsReady, 'merge');
    useMyReviewNotification([...pullsNeedingCR, ...pullsNeedingQA], 're-review');
    return (<>
@@ -49,7 +48,7 @@ export const Pulldasher: React.FC = function() {
                </Box>
             </SimpleGrid>
          </VStack>
-         {showClosedPulls && <ClosedPulls onClickClose={() => setShowClosedPulls(false)}/>}
+         {showClosedPulls && <ClosedPulls onClickClose={toggleShowClosedPulls}/>}
       </Box>
    </>);
 }

--- a/frontend/src/pulldasher/pulls-context.tsx
+++ b/frontend/src/pulldasher/pulls-context.tsx
@@ -9,6 +9,8 @@ interface PullContextProps {
    allPulls: Pull[];
    // Sorted array of all open pulls (open)
    allOpenPulls: Pull[];
+   // Array of pulls from allPulls that pass the filter function
+   filteredPulls: Pull[];
    // Set of open pulls passing the filter function
    filteredOpenPulls: Set<Pull>;
    // Changes the filter function
@@ -19,6 +21,7 @@ const defaultProps = {
    allPulls: [],
    allOpenPulls: [],
    filteredOpenPulls: new Set<Pull>(),
+   filteredPulls: [],
    // Default implementation is a no-op, just so there's
    // something there until the provider is used
    setFilter: (name:string, filter:FilterFunction) => filter,
@@ -37,6 +40,10 @@ export function useFilteredOpenPulls(): Set<Pull> {
    return useContext(PullsContext).filteredOpenPulls;
 }
 
+export function useFilteredPulls(): Pull[] {
+   return useContext(PullsContext).filteredPulls;
+}
+
 export function useSetFilter(): FilterFunctionSetter {
    return useContext(PullsContext).setFilter;
 }
@@ -48,6 +55,7 @@ export const PullsProvider = function({children}: {children: React.ReactNode}) {
    const contextValue = {
       filteredOpenPulls: new Set(filteredPulls.filter(isOpen)),
       allOpenPulls: openPulls.sort(defaultCompare),
+      filteredPulls: filteredPulls,
       allPulls: unfilteredPulls,
       setFilter
    };

--- a/frontend/src/pulldasher/pulls-context.tsx
+++ b/frontend/src/pulldasher/pulls-context.tsx
@@ -9,8 +9,8 @@ interface PullContextProps {
    allPulls: Pull[];
    // Sorted array of all open pulls (open)
    allOpenPulls: Pull[];
-   // Set pf pulls passing the filter function
-   pulls: Set<Pull>;
+   // Set of open pulls passing the filter function
+   filteredOpenPulls: Set<Pull>;
    // Changes the filter function
    setFilter: FilterFunctionSetter;
 }
@@ -18,7 +18,7 @@ interface PullContextProps {
 const defaultProps = {
    allPulls: [],
    allOpenPulls: [],
-   pulls: new Set<Pull>(),
+   filteredOpenPulls: new Set<Pull>(),
    // Default implementation is a no-op, just so there's
    // something there until the provider is used
    setFilter: (name:string, filter:FilterFunction) => filter,
@@ -34,7 +34,7 @@ export function useAllPulls(): Pull[] {
 }
 
 export function usePulls(): Set<Pull> {
-   return useContext(PullsContext).pulls;
+   return useContext(PullsContext).filteredOpenPulls;
 }
 
 export function useSetFilter(): FilterFunctionSetter {
@@ -46,7 +46,7 @@ export const PullsProvider = function({children}: {children: React.ReactNode}) {
    const [filteredPulls, setFilter] = useFilteredPullsState(unfilteredPulls);
    const openPulls = unfilteredPulls.filter(isOpen);
    const contextValue = {
-      pulls: new Set(filteredPulls.filter(isOpen)),
+      filteredOpenPulls: new Set(filteredPulls.filter(isOpen)),
       allOpenPulls: openPulls.sort(defaultCompare),
       allPulls: unfilteredPulls,
       setFilter

--- a/frontend/src/pulldasher/pulls-context.tsx
+++ b/frontend/src/pulldasher/pulls-context.tsx
@@ -23,7 +23,7 @@ const defaultProps = {
    // something there until the provider is used
    setFilter: (name:string, filter:FilterFunction) => filter,
 }
-export const PullsContext = createContext<PullContextProps>(defaultProps);
+const PullsContext = createContext<PullContextProps>(defaultProps);
 
 export function useAllOpenPulls(): Pull[] {
    return useContext(PullsContext).allOpenPulls;

--- a/frontend/src/pulldasher/pulls-context.tsx
+++ b/frontend/src/pulldasher/pulls-context.tsx
@@ -44,7 +44,7 @@ export function useSetFilter(): FilterFunctionSetter {
 export const PullsProvider = function({children}: {children: React.ReactNode}) {
    const unfilteredPulls = usePullsState();
    const [filteredPulls, setFilter] = useFilteredPullsState(unfilteredPulls);
-   const openPulls = unfilteredPulls.filter((pull) => pull.isOpen());
+   const openPulls = unfilteredPulls.filter(isOpen);
    const contextValue = {
       pulls: new Set(filteredPulls),
       allOpenPulls: openPulls.sort(defaultCompare),
@@ -55,3 +55,5 @@ export const PullsProvider = function({children}: {children: React.ReactNode}) {
       {children}
    </PullsContext.Provider>);
 }
+
+const isOpen = (pull: Pull) => pull.isOpen();

--- a/frontend/src/pulldasher/pulls-context.tsx
+++ b/frontend/src/pulldasher/pulls-context.tsx
@@ -33,7 +33,7 @@ export function useAllPulls(): Pull[] {
    return useContext(PullsContext).allPulls;
 }
 
-export function usePulls(): Set<Pull> {
+export function useFilteredOpenPulls(): Set<Pull> {
    return useContext(PullsContext).filteredOpenPulls;
 }
 

--- a/frontend/src/pulldasher/pulls-context.tsx
+++ b/frontend/src/pulldasher/pulls-context.tsx
@@ -46,7 +46,7 @@ export const PullsProvider = function({children}: {children: React.ReactNode}) {
    const [filteredPulls, setFilter] = useFilteredPullsState(unfilteredPulls);
    const openPulls = unfilteredPulls.filter(isOpen);
    const contextValue = {
-      pulls: new Set(filteredPulls),
+      pulls: new Set(filteredPulls.filter(isOpen)),
       allOpenPulls: openPulls.sort(defaultCompare),
       allPulls: unfilteredPulls,
       setFilter

--- a/frontend/src/pulldasher/pulls-state.tsx
+++ b/frontend/src/pulldasher/pulls-state.tsx
@@ -28,7 +28,7 @@ export function usePullsState(): Pull[] {
    const [pullState, setPullsState] = useState<Pull[]>([]);
    useEffect(() => {
       if (socketInitialized) {
-         throw new Error("usePullsState() connects to socket-io and is only meant to be used in the PullsProvider component, see usePulls() instead.");
+         throw new Error("usePullsState() connects to socket-io and is only meant to be used in the PullsProvider component, see useFilteredOpenPulls() instead.");
       }
       socketInitialized = true;
       onPullsChanged(setPullsState);

--- a/frontend/src/pulldasher/sort.ts
+++ b/frontend/src/pulldasher/sort.ts
@@ -39,6 +39,12 @@ export function signatureCompare(a: Signature, b: Signature) {
    );
 }
 
+export function closedAtCompare(a: Pull, b: Pull) {
+   const astr = String(a.closed_at);
+   const bstr = String(b.closed_at);
+   return astr < bstr ? 1 : (astr > bstr ? -1 : 0);
+}
+
 function isQAingByMe(pull: Pull): boolean {
    const label = pull.getLabel('QAing');
    return label?.user == getUser();

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -68,6 +68,9 @@ export const theme = extendTheme({
                   borderLeft: "solid 1px var(--panel-ready-count-border)",
                   background: "var(--panel-ready-count-background)",
                },
+            },
+            "closed": {
+               borderRadius: 0,
             }
          }
       },

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -70,8 +70,11 @@ export const theme = extendTheme({
                },
             },
             "closed": {
-               borderRadius: 0,
+               borderRadius: "7px 0 0 7px",
                backgroundColor: "var(--background-color)",
+               "& .column_header": {
+                  borderRadius: "7px 0 0 0",
+               }
             }
          }
       },

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -71,6 +71,7 @@ export const theme = extendTheme({
             },
             "closed": {
                borderRadius: 0,
+               backgroundColor: "var(--background-color)",
             }
          }
       },

--- a/frontend/src/theme/day_theme.less
+++ b/frontend/src/theme/day_theme.less
@@ -5,6 +5,9 @@ body[data-theme="day_theme"] {
     @yellow: #E7B049;
     @red:    #DB524B;
 
+    @closed: #CF222E;
+    @merged: #8250DF;
+
     @white:      #FFFFFF;
     @light-grey: #F5F5F5;
     @grey:       #E7E7E7;
@@ -82,6 +85,8 @@ body[data-theme="day_theme"] {
     --pull-background-hover: @light-grey;
     --pull-separator: darken(@light-grey, 10%);
     --pull-updated-background: #fff3a6;
+    --pull-merged: @merged;
+    --pull-closed: @closed;
 
     // Build statuses
     --build-state-pending: @grey;

--- a/frontend/src/use-url-state.ts
+++ b/frontend/src/use-url-state.ts
@@ -75,14 +75,17 @@ function urlToStateObject(url: URL): HistoryState {
 /**
  * Just like useUrlState(), but typed for storing a boolean
  */
-export function useBoolUrlState(paramName: string, paramDefault: boolean): [boolean, (state: boolean|null) => void] {
+export function useBoolUrlState(paramName: string, paramDefault: boolean): [boolean, () => void] {
    const [state, setState] = useUrlState(paramName, paramDefault ? '1' : '0');
 
-   const setBoolState = useCallback((newState: boolean) => {
-      setState(newState ? '1' : '0');
-   }, []);
+   const toggleBoolState = useCallback(() => {
+      const newState = state == '0' ? '1' : '0';
+      console.log(`Toggling ${paramName} from ${state} to ${newState}`);
+      setState(newState)
+   }
+   , [state]);
 
-   return [state === '1', setBoolState];
+   return [state === '1', toggleBoolState];
 }
 
 /**


### PR DESCRIPTION
Adds a new column that shows a sorted array of all the closed pulls from the last two weeks. We already have all this data on the client side. This adds a view on that data to see at a quick glance which pulls were recently merged.

It should:

* Remain sorted with recent merges / closures at the top
* Style closed and merged pulls differently
* Allow being hidden / shown 
* Respect current filters (repo, author, search)

![image](https://user-images.githubusercontent.com/26855/207004251-303d4aad-11e8-4e32-a34f-71beacec2e11.png)

Closes #303