### PR TITLE
Deploy block dependent pull requests

### DIFF
--- a/frontend/src/pull-card/flags.tsx
+++ b/frontend/src/pull-card/flags.tsx
@@ -18,6 +18,7 @@ export const Flags = memo(function Flags({ pull }: { pull: Pull }) {
   const devBlock = pull.getDevBlock();
   const draftBlock = pull.isDraft();
   const readyButNoCI = pull.isReady() && !pull.isCiRequired();
+  const dependentPR = pull.isDependent() && !pull.getDeployBlock() && pull.isCiRequired() && !pull.isDraft();
   const deployBlock = pull.getDeployBlock();
   const QAing = pull.getLabel("QAing");
   const externalBlock = pull.getLabel("external_block");
@@ -40,6 +41,13 @@ export const Flags = memo(function Flags({ pull }: { pull: Pull }) {
         <PullFlag
           variant="deployBlock"
           title={"No CI, deploy carefully"}
+          icon={faWarning}
+        />
+      )}
+      {dependentPR && (
+        <PullFlag
+          variant="deployBlock"
+          title={"This pull request is waiting for another to merge"}
           icon={faWarning}
         />
       )}

--- a/frontend/src/pull-card/flags.tsx
+++ b/frontend/src/pull-card/flags.tsx
@@ -12,13 +12,14 @@ import {
   faSnowflake,
   faSpinner,
   faCodeCompare,
+  faCodeBranch,
 } from "@fortawesome/free-solid-svg-icons";
 
 export const Flags = memo(function Flags({ pull }: { pull: Pull }) {
   const devBlock = pull.getDevBlock();
   const draftBlock = pull.isDraft();
   const readyButNoCI = pull.isReady() && !pull.isCiRequired();
-  const dependentPR = pull.isDependent() && !pull.getDeployBlock() && pull.isCiRequired() && !pull.isDraft();
+  const dependentPR = pull.isDependent();
   const deployBlock = pull.getDeployBlock();
   const QAing = pull.getLabel("QAing");
   const externalBlock = pull.getLabel("external_block");
@@ -46,9 +47,9 @@ export const Flags = memo(function Flags({ pull }: { pull: Pull }) {
       )}
       {dependentPR && (
         <PullFlag
-          variant="deployBlock"
+          variant="dependentPR"
           title={"This pull request is waiting for another to merge"}
-          icon={faWarning}
+          icon={faCodeBranch}
         />
       )}
       {devBlock && (

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -115,8 +115,12 @@ export class Pull extends PullData {
     return (
       this.hasMetDeployRequirements() &&
       !this.getDevBlock() &&
-      (!!this.getDeployBlock() || !this.isCiRequired() || this.hasMergeConflicts())
+      (!!this.getDeployBlock() || !this.isCiRequired() || this.hasMergeConflicts() || this.isDependent())
     );
+  }
+
+  isDependent(): boolean {
+    return !(this.base.ref == "main" || this.base.ref == "master");
   }
 
   hasMetDeployRequirements(): boolean {

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -215,6 +215,11 @@ export const theme = extendTheme({
           backgroundColor: "var(--tag-merge-conflict-background)",
           borderColor: "var(--tag-merge-conflict-border)",
         },
+        dependentPR: {
+          color: "var(--tag-dependent-pr)",
+          backgroundColor: "var(--tag-dependent-pr-background)",
+          borderColor: "var(--tag-dependent-pr-border)",
+        },
       },
     },
   },

--- a/frontend/src/theme/day_theme.less
+++ b/frontend/src/theme/day_theme.less
@@ -137,6 +137,10 @@ body[data-theme="day_theme"] {
   --tag-merge-conflict-border: var(--tag-default-border);
   --tag-merge-conflict-background: var(--tag-default-background);
 
+  --tag-dependent-pr: @red;
+  --tag-dependent-pr-border: var(--tag-default-border);
+  --tag-dependent-pr-background: var(--tag-default-background);
+
   --user-icon: @blue;
 
   // Pull age

--- a/frontend/src/theme/night_theme.less
+++ b/frontend/src/theme/night_theme.less
@@ -133,6 +133,10 @@ body[data-theme="night_theme"] {
   --tag-merge-conflict-border: var(--tag-default-border);
   --tag-merge-conflict-background: var(--tag-default-background);
 
+  --tag-dependent-pr: @red;
+  --tag-dependent-pr-border: var(--tag-default-border);
+  --tag-dependent-pr-background: var(--tag-default-background);
+
   --user-icon: @blue;
 
   // Pull age

--- a/frontend/test/named-pulls.ts
+++ b/frontend/test/named-pulls.ts
@@ -294,6 +294,12 @@ export const Blocked = <PullData[]>[
     title: "Merge Conflict(s)",
     mergeable: false,
   }),
+  pullData({
+    title: "Awaiting a merge",
+    base: {
+      ref: "not-main",
+    },
+  }),
 ];
 
 export const Milestones = <PullData[]>[
@@ -381,6 +387,9 @@ export const KitchenSink = <PullData[]>[
     title: "Pull With Lots of flags and such and a really long title",
     user: {
       login: getUser(),
+    },
+    base: {
+      ref: "not-main",
     },
     mergeable: false,
     draft: true,

--- a/frontend/test/pull-data-parts.ts
+++ b/frontend/test/pull-data-parts.ts
@@ -94,7 +94,7 @@ export function pullData(p: DeepPartial<PullData>): PullData {
     },
     head: head,
     base: {
-      ref: "master",
+      ref: p.base?.ref || "main",
     },
     user: {
       login: p.user?.login || username(),


### PR DESCRIPTION
### Preview:

This will automatically add a flag to pull requests that are based off of another branch, which will no longer require pull authors to make a _deploy_block_ signature comment in these instances.

![WrXnWjX9pj](https://user-images.githubusercontent.com/95656772/225988695-74f72cde-cde3-42c9-a6c1-3c3fea07966f.png)

---

### Changes Made:
1. Added a new function to determine if a pull request is based off another branch
2. Updated the **Deploy Blocked** column filtering
3. Created a new flag const (which is a deployBlock variant)

---

### CR Notes:

CR: Review to https://github.com/iFixit/pulldasher/pull/360/commits/857744a5f72bd03861d1bf5bb0a0c6c40cca62b1


### Testing Procedure:

1. Checkout | merge with [`deploy_block-dependent-prs`](https://github.com/iFixit/pulldasher/tree/deploy_block-dependent-prs)
2. `update-pulldasher-dev --run .`
3. Find/create a pull request that is based off of another branch
4. Ensure that there is a deploy block variant on this pull card

https://pulldasher-dev.cominor.com/

---

Closes #338 