### PR TITLE
Add href to dependent pull requests

### DIFF
--- a/frontend/src/pull-card/flags.tsx
+++ b/frontend/src/pull-card/flags.tsx
@@ -48,8 +48,9 @@ export const Flags = memo(function Flags({ pull }: { pull: Pull }) {
       {dependentPR && (
         <PullFlag
           variant="dependentPR"
-          title={"This pull request is waiting for another to merge"}
+          title={"This pull request is waiting for a branch to merge"}
           icon={faCodeBranch}
+          href={pull.linkToBranch()}
         />
       )}
       {devBlock && (

--- a/frontend/src/pull-card/flags.tsx
+++ b/frontend/src/pull-card/flags.tsx
@@ -50,7 +50,7 @@ export const Flags = memo(function Flags({ pull }: { pull: Pull }) {
           variant="dependentPR"
           title={"This pull request is waiting for a branch to merge"}
           icon={faCodeBranch}
-          href={pull.linkToBranch()}
+          href={pull.getUrlOfBaseBranch()}
         />
       )}
       {devBlock && (

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -187,6 +187,10 @@ export class Pull extends PullData {
     const linkIdPrefix = isReview ? "pullrequestreview" : "issuecomment";
     return this.url() + `#${linkIdPrefix}-${sig.data.comment_id}`;
   }
+
+  linkToBranch() {
+    return "https://github.com/" + this.repo + "/tree/" + this.base.ref;
+  }
 }
 
 function computeSignatures(signatures: Signature[]): SignatureGroup {

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -189,7 +189,7 @@ export class Pull extends PullData {
   }
 
   getUrlOfBaseBranch() {
-    return "https://github.com/" + this.repo + "/compare/" + this.base.ref;
+    return "https://github.com/" + this.repo + "/compare/" + encodeURIComponent(this.base.ref);
   }
 }
 

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -188,7 +188,7 @@ export class Pull extends PullData {
     return this.url() + `#${linkIdPrefix}-${sig.data.comment_id}`;
   }
 
-  linkToBranch() {
+  getUrlOfBaseBranch() {
     return "https://github.com/" + this.repo + "/compare/" + this.base.ref;
   }
 }

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -189,7 +189,7 @@ export class Pull extends PullData {
   }
 
   linkToBranch() {
-    return "https://github.com/" + this.repo + "/tree/" + this.base.ref;
+    return "https://github.com/" + this.repo + "/compare/" + this.base.ref;
   }
 }
 


### PR DESCRIPTION
### Preview:

![dependent](https://user-images.githubusercontent.com/95656772/226431245-9fdbd373-f81c-4467-8952-14dc5706b931.png)

![pull-request](https://user-images.githubusercontent.com/95656772/226431248-b2ad39e4-db5d-4c41-a89b-0642ce80e843.jpg)

This href will link to the dependent pull request's base branch (outlined above)