### PR TITLE
Move ready, no-CI pulls

### DIFF
--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -115,7 +115,7 @@ export class Pull extends PullData {
     return (
       this.hasMetDeployRequirements() &&
       !this.getDevBlock() &&
-      (!!this.getDeployBlock() || !this.isCiRequired() || this.hasMergeConflicts() || this.isDependent())
+      (!!this.getDeployBlock() || this.hasMergeConflicts() || this.isDependent())
     );
   }
 

--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -35,7 +35,7 @@ function Pulldasher() {
   const pullsCIBlocked = pulls.filter((pull) => pull.isCiBlocked());
   const pullsDeployBlocked = pulls.filter((pull) => pull.isDeployBlocked());
   const pullsReady = pulls.filter(
-    (pull) => pull.isReady() && pull.isCiRequired()
+    (pull) => pull.isReady()
   );
   const pullsDevBlocked = pulls.filter(
     (pull) => pull.getDevBlock() || pull.isDraft()


### PR DESCRIPTION
**Before/After**

![B4](https://user-images.githubusercontent.com/95656772/228966185-3b38a4c8-40ae-417f-9196-c4937e55c8ca.png)
![After](https://user-images.githubusercontent.com/95656772/228966189-c6be6ece-7bbc-4294-8417-7b05fd3443ba.png)


qa_req 0
Closes #164 