### PR TITLE
Commit Checks: Use new api location

### DIFF
--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -155,7 +155,7 @@ module.exports = {
     var comments = getIssueComments(repo, githubPull.number);
     var headCommit = getCommit(repo, githubPull.head.sha);
     var commitStatuses = getCommitStatuses(repo, githubPull.head.sha);
-    var commitChecks = getCommitChecks(repo, githubPull.head.sha);
+    var commitChecks = getWorkflowRuns(repo, githubPull.head.sha);
     var events = getIssueEvents(repo, githubPull.number);
     // Only so we have the canonical list of labels.
     var ghIssue = module.exports.getIssue(repo, githubPull.number);
@@ -509,10 +509,10 @@ function getCommitStatuses(repo, ref) {
   );
 }
 
-function getCommitChecks(repo, ref) {
+function getWorkflowRuns(repo, ref) {
   return logErrors(
-    githubRest.checks
-      .listForRef(params({ ref }, repo))
+    githubRest.actions
+      .listWorkflowRunsForRepo(params({ head_sha: ref }, repo))
       .then((res) => res.data.check_runs)
       .then((check_runs) => check_runs || []),
     "Getting commit checks for %s:%s",

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -511,8 +511,17 @@ function getCommitStatuses(repo, ref) {
 
 function getWorkflowRuns(repo, ref) {
   return logErrors(
-    githubRest.actions
-      .listWorkflowRunsForRepo(params({ head_sha: ref }, repo))
+    github
+      .paginate(
+        githubRest.actions.listWorkflowRunsForRepo,
+        params(
+          {
+            head_sha: ref,
+            exclude_pull_requests: true,
+          },
+          repo
+        )
+      )
       .then((res) => res.data.check_runs)
       .then((check_runs) => check_runs || []),
     "Getting commit checks for %s:%s",

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -522,9 +522,8 @@ function getWorkflowRuns(repo, ref) {
           repo
         )
       )
-      .then((res) => res.data.check_runs)
-      .then((check_runs) => check_runs || []),
-    "Getting commit checks for %s:%s",
+      .then((runs) => runs || []),
+    "Getting workflow runs for %s:%s",
     repo,
     ref
   );

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -155,7 +155,7 @@ module.exports = {
     var comments = getIssueComments(repo, githubPull.number);
     var headCommit = getCommit(repo, githubPull.head.sha);
     var commitStatuses = getCommitStatuses(repo, githubPull.head.sha);
-    var commitChecks = getWorkflowRuns(repo, githubPull.head.sha);
+    var workflowRuns = getWorkflowRuns(repo, githubPull.head.sha);
     var events = getIssueEvents(repo, githubPull.number);
     // Only so we have the canonical list of labels.
     var ghIssue = module.exports.getIssue(repo, githubPull.number);
@@ -168,7 +168,7 @@ module.exports = {
       comments,
       headCommit,
       commitStatuses,
-      commitChecks,
+      workflowRuns,
       events,
       ghIssue,
       reviews,
@@ -177,7 +177,7 @@ module.exports = {
         comments = results[1],
         headCommit = results[2],
         commitStatuses = results[3],
-        commitChecks = results[4],
+        workflowRuns = results[4],
         events = results[5],
         ghIssue = results[6],
         reviews = results[7];
@@ -255,13 +255,13 @@ module.exports = {
         });
       });
 
-      let checks = commitChecks.map(function (commitCheck) {
+      let checks = workflowRuns.map(function (workflowRun) {
         let state = utils.mapCheckToStatus(
-          commitCheck.conclusion || commitCheck.status
+          workflowRun.conclusion || workflowRun.status
         );
         let desc = state;
-        let url = commitCheck.html_url;
-        let context = commitCheck.name;
+        let url = workflowRun.html_url;
+        let context = workflowRun.name;
 
         return new Status({
           repo: repo,
@@ -270,8 +270,8 @@ module.exports = {
           description: desc,
           target_url: url,
           context: context,
-          started_at: commitCheck.started_at,
-          completed_at: commitCheck.completed_at,
+          started_at: workflowRun.started_at,
+          completed_at: workflowRun.completed_at,
         });
       });
 

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -155,7 +155,7 @@ module.exports = {
     var comments = getIssueComments(repo, githubPull.number);
     var headCommit = getCommit(repo, githubPull.head.sha);
     var commitStatuses = getCommitStatuses(repo, githubPull.head.sha);
-    var workflowRuns = getWorkflowRuns(repo, githubPull.head.sha);
+    var jobRuns = getAllJobRuns(repo, githubPull.head.sha);
     var events = getIssueEvents(repo, githubPull.number);
     // Only so we have the canonical list of labels.
     var ghIssue = module.exports.getIssue(repo, githubPull.number);
@@ -168,7 +168,7 @@ module.exports = {
       comments,
       headCommit,
       commitStatuses,
-      workflowRuns,
+      jobRuns,
       events,
       ghIssue,
       reviews,
@@ -177,7 +177,7 @@ module.exports = {
         comments = results[1],
         headCommit = results[2],
         commitStatuses = results[3],
-        workflowRuns = results[4],
+        jobRuns = results[4],
         events = results[5],
         ghIssue = results[6],
         reviews = results[7];
@@ -255,13 +255,11 @@ module.exports = {
         });
       });
 
-      let checks = workflowRuns.map(function (workflowRun) {
-        let state = utils.mapCheckToStatus(
-          workflowRun.conclusion || workflowRun.status
-        );
+      let checks = jobRuns.map(function (jobRun) {
+        let state = utils.mapCheckToStatus(jobRun.conclusion || jobRun.status);
         let desc = state;
-        let url = workflowRun.html_url;
-        let context = workflowRun.name;
+        let url = jobRun.html_url;
+        let context = jobRun.name;
 
         return new Status({
           repo: repo,
@@ -270,8 +268,8 @@ module.exports = {
           description: desc,
           target_url: url,
           context: context,
-          started_at: workflowRun.started_at,
-          completed_at: workflowRun.completed_at,
+          started_at: jobRun.started_at,
+          completed_at: jobRun.completed_at,
         });
       });
 
@@ -509,7 +507,7 @@ function getCommitStatuses(repo, ref) {
   );
 }
 
-function getWorkflowRuns(repo, ref) {
+function getAllJobRuns(repo, ref) {
   return logErrors(
     github
       .paginate(
@@ -522,10 +520,30 @@ function getWorkflowRuns(repo, ref) {
           repo
         )
       )
-      .then((runs) => runs || []),
+      .then((runs) => Promise.all((runs || []).map(getJobRunsFromWorkflow)))
+      .then((runs) => runs.flat(1)),
     "Getting workflow runs for %s:%s",
     repo,
     ref
+  );
+}
+
+function getJobRunsFromWorkflow(workflowRun) {
+  return logErrors(
+    github
+      .paginate(
+        githubRest.actions.listJobsForWorkflowRun,
+        params(
+          {
+            run_id: workflowRun.id,
+          },
+          workflowRun.repository.full_name
+        )
+      )
+      .then((jobs) => jobs || []),
+    "Getting jobs runs for %s:%s",
+    workflowRun.repository.full_name,
+    workflowRun.name
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.0.0",
         "@fortawesome/react-fontawesome": "^0.1.17",
         "@octokit/plugin-throttling": "^3.4.1",
-        "@octokit/rest": "^18.5.3",
+        "@octokit/rest": "^19.0.7",
         "@types/underscore": "^1.10.24",
         "bluebird": "^3.7.1",
         "body-parser": "^1.19.0",
@@ -2901,6 +2901,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
       "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^6.0.3"
       }
@@ -2909,6 +2910,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -2923,6 +2925,7 @@
       "version": "6.0.12",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
       "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^6.0.3",
         "is-plain-object": "^5.0.0",
@@ -2933,6 +2936,7 @@
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
       "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "peer": true,
       "dependencies": {
         "@octokit/request": "^5.6.0",
         "@octokit/types": "^6.0.3",
@@ -2944,17 +2948,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
       "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
     },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
-      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
-      "dependencies": {
-        "@octokit/types": "^6.34.0"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=2"
-      }
-    },
     "node_modules/@octokit/plugin-request-log": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
@@ -2964,15 +2957,31 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
-      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.0.1.tgz",
+      "integrity": "sha512-pnCaLwZBudK5xCdrR823xHGNgqOzRnJ/mpC/76YPpNP7DybdsJtP7mdOwh+wYZxK5jqeQuhu59ogMI4NRlBUvA==",
       "dependencies": {
-        "@octokit/types": "^6.34.0",
+        "@octokit/types": "^9.0.0",
         "deprecation": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14"
       },
       "peerDependencies": {
         "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^16.0.0"
       }
     },
     "node_modules/@octokit/plugin-throttling": {
@@ -2991,6 +3000,7 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
       "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "peer": true,
       "dependencies": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
@@ -3004,6 +3014,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
       "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
@@ -3011,14 +3022,127 @@
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "18.12.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "version": "19.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.7.tgz",
+      "integrity": "sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==",
       "dependencies": {
-        "@octokit/core": "^3.5.1",
-        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/core": "^4.1.0",
+        "@octokit/plugin-paginate-rest": "^6.0.0",
         "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+        "@octokit/plugin-rest-endpoint-methods": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
+      "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==",
+      "dependencies": {
+        "@octokit/auth-token": "^3.0.0",
+        "@octokit/graphql": "^5.0.0",
+        "@octokit/request": "^6.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
+      "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/graphql": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.5.tgz",
+      "integrity": "sha512-Qwfvh3xdqKtIznjX9lz2D458r7dJPP8l6r4GQkIdWQouZwHQK0mVT88uwiU2bdTU2OtT1uOlKpRciUWldpG0yQ==",
+      "dependencies": {
+        "@octokit/request": "^6.0.0",
+        "@octokit/types": "^9.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.0.0.tgz",
+      "integrity": "sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=4"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/request": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.3.tgz",
+      "integrity": "sha512-TNAodj5yNzrrZ/VxP+H5HiYaZep0H3GU0O7PaF+fhDrt8FPrnkei9Aal/txsN/1P7V3CPiThG0tIvpPDYUsyAA==",
+      "dependencies": {
+        "@octokit/endpoint": "^7.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/request-error": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest/node_modules/@octokit/types": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^16.0.0"
       }
     },
     "node_modules/@octokit/types": {
@@ -13273,6 +13397,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
       "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "peer": true,
       "requires": {
         "@octokit/types": "^6.0.3"
       }
@@ -13281,6 +13406,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "peer": true,
       "requires": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -13295,6 +13421,7 @@
       "version": "6.0.12",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
       "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "peer": true,
       "requires": {
         "@octokit/types": "^6.0.3",
         "is-plain-object": "^5.0.0",
@@ -13305,6 +13432,7 @@
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
       "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "peer": true,
       "requires": {
         "@octokit/request": "^5.6.0",
         "@octokit/types": "^6.0.3",
@@ -13316,14 +13444,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
       "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
     },
-    "@octokit/plugin-paginate-rest": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
-      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
-      "requires": {
-        "@octokit/types": "^6.34.0"
-      }
-    },
     "@octokit/plugin-request-log": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
@@ -13331,12 +13451,27 @@
       "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
-      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.0.1.tgz",
+      "integrity": "sha512-pnCaLwZBudK5xCdrR823xHGNgqOzRnJ/mpC/76YPpNP7DybdsJtP7mdOwh+wYZxK5jqeQuhu59ogMI4NRlBUvA==",
       "requires": {
-        "@octokit/types": "^6.34.0",
+        "@octokit/types": "^9.0.0",
         "deprecation": "^2.3.1"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+          "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
+        },
+        "@octokit/types": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+          "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+          "requires": {
+            "@octokit/openapi-types": "^16.0.0"
+          }
+        }
       }
     },
     "@octokit/plugin-throttling": {
@@ -13352,6 +13487,7 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
       "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "peer": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
@@ -13365,6 +13501,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
       "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "peer": true,
       "requires": {
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
@@ -13372,14 +13509,102 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.12.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "version": "19.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.7.tgz",
+      "integrity": "sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==",
       "requires": {
-        "@octokit/core": "^3.5.1",
-        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/core": "^4.1.0",
+        "@octokit/plugin-paginate-rest": "^6.0.0",
         "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+        "@octokit/plugin-rest-endpoint-methods": "^7.0.0"
+      },
+      "dependencies": {
+        "@octokit/auth-token": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
+          "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
+          "requires": {
+            "@octokit/types": "^9.0.0"
+          }
+        },
+        "@octokit/core": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.0.tgz",
+          "integrity": "sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==",
+          "requires": {
+            "@octokit/auth-token": "^3.0.0",
+            "@octokit/graphql": "^5.0.0",
+            "@octokit/request": "^6.0.0",
+            "@octokit/request-error": "^3.0.0",
+            "@octokit/types": "^9.0.0",
+            "before-after-hook": "^2.2.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/endpoint": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
+          "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
+          "requires": {
+            "@octokit/types": "^9.0.0",
+            "is-plain-object": "^5.0.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/graphql": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.5.tgz",
+          "integrity": "sha512-Qwfvh3xdqKtIznjX9lz2D458r7dJPP8l6r4GQkIdWQouZwHQK0mVT88uwiU2bdTU2OtT1uOlKpRciUWldpG0yQ==",
+          "requires": {
+            "@octokit/request": "^6.0.0",
+            "@octokit/types": "^9.0.0",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/openapi-types": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+          "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
+        },
+        "@octokit/plugin-paginate-rest": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.0.0.tgz",
+          "integrity": "sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==",
+          "requires": {
+            "@octokit/types": "^9.0.0"
+          }
+        },
+        "@octokit/request": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.3.tgz",
+          "integrity": "sha512-TNAodj5yNzrrZ/VxP+H5HiYaZep0H3GU0O7PaF+fhDrt8FPrnkei9Aal/txsN/1P7V3CPiThG0tIvpPDYUsyAA==",
+          "requires": {
+            "@octokit/endpoint": "^7.0.0",
+            "@octokit/request-error": "^3.0.0",
+            "@octokit/types": "^9.0.0",
+            "is-plain-object": "^5.0.0",
+            "node-fetch": "^2.6.7",
+            "universal-user-agent": "^6.0.0"
+          }
+        },
+        "@octokit/request-error": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+          "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+          "requires": {
+            "@octokit/types": "^9.0.0",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "@octokit/types": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+          "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+          "requires": {
+            "@octokit/openapi-types": "^16.0.0"
+          }
+        }
       }
     },
     "@octokit/types": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
     "@fortawesome/react-fontawesome": "^0.1.17",
     "@octokit/plugin-throttling": "^3.4.1",
-    "@octokit/rest": "^18.5.3",
+    "@octokit/rest": "^19.0.7",
     "@types/underscore": "^1.10.24",
     "bluebird": "^3.7.1",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
The old checks endpoint isn't supported by github's new Fine Grained
Personal Access Tokens; but this equivalent endpoint is.