### PR TITLE
GitHub Actions: Resolve warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: npm


### PR DESCRIPTION
## Summary
Update actions checkout and setup-node to `v3`.

Resolves `Node.js 12 actions are deprecated` and `The 'set-output' command is deprecated` warnings.

## QA notes
Check the summary of the `build` CI check and make sure we don't see the following warnings:
- `Node.js 12 actions are deprecated` 
- `The 'set-output' command is deprecated`

Note: `Build: frontend/src/pull-card/index.tsx#L202` warning is unrelated to github actions deprecation warnings. 

connects https://github.com/ifixit/ifixit/issues/47011