### PR TITLE
Fix 'undefined' title

### DIFF
--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -72,7 +72,7 @@ export function Navbar(props: NavBarProps) {
   );
   // Set the page title
   const title = getTitle();
-  useEffect(() => { document.title = title; }, [title]);
+  useEffect(() => { document.title = title || ''; }, [title]);
 
   return (
     <Center


### PR DESCRIPTION
### Issue:

![firefox_N1gRqWmhRi](https://user-images.githubusercontent.com/95656772/235513571-298230ef-9b26-4b75-8ac4-c3554c11b0e4.gif)

This pull request will use an empty string if the `title` prop is _falsy_ instead of defaulting to 'undefined'