### PR TITLE
Signatures: treat dev_block as out-of-date CR

### DIFF
--- a/frontend/src/pull-card/index.tsx
+++ b/frontend/src/pull-card/index.tsx
@@ -196,9 +196,9 @@ const formatDate = (dateStr: string | null) => {
   return dateStr ? formatter.format(new Date(dateStr)) : null;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function highlightOnChange(
   ref: RefObject<HTMLElement>,
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
   dependencies: Array<any>
 ) {
   // Animate a highlight when pull.received_at changes


### PR DESCRIPTION
When you "dev_block" something, have that inject a "synthetic" but out-of-date CR signature in the UI. This means that a dev_block somewhat reserves a place for you to CR it in the future.

Most dev_blocks come after a review and we generally presume that the dev blocker will come back and CR it after the requested changes have been made. Therefore, we now show a dev_block as an "inactive" CR.

Also, move the typescript comment to the line it's referring to.

Closes #193