### PR TITLE
Recently Closed Pulls: Fix cut-off

### DIFF
--- a/frontend/src/closed-pulls.tsx
+++ b/frontend/src/closed-pulls.tsx
@@ -21,6 +21,7 @@ export function ClosedPulls({ onClickClose }: { onClickClose: () => void }) {
       top="70"
       bottom="0"
       width="300px"
+      height="fit-content"
       boxShadow="0px 0px 10px 0px #00000020"
     >
       <Flex className="column_header" onClick={onClickClose}>

--- a/frontend/src/closed-pulls.tsx
+++ b/frontend/src/closed-pulls.tsx
@@ -19,7 +19,6 @@ export function ClosedPulls({ onClickClose }: { onClickClose: () => void }) {
       position="absolute"
       right="0"
       top="70"
-      bottom="0"
       width="300px"
       boxShadow="0px 0px 10px 0px #00000020"
     >

--- a/frontend/src/closed-pulls.tsx
+++ b/frontend/src/closed-pulls.tsx
@@ -19,6 +19,7 @@ export function ClosedPulls({ onClickClose }: { onClickClose: () => void }) {
       position="absolute"
       right="0"
       top="70"
+      bottom="0"
       width="300px"
       boxShadow="0px 0px 10px 0px #00000020"
     >


### PR DESCRIPTION
### Summary

The background of the _Recently Closed Pulls_ section wasn't reaching down to the bottom of the PR list

<details>
<summary> Toggle View </summary> <br>

![firefox_e2MhDptouK](https://github.com/iFixit/pulldasher/assets/95656772/55771759-76a2-4dd7-a66a-d2b8f4302dff)
</details>

---

### CR/QA Notes:

**CR:** Adds a **height** CSS prop

**QA:** [Overlord Documentation](https://overlord.ifixit.com/Guide/How+to+test+Pulldasher+with+Pulldasher-dev/1124)

This can easily be checked by using browser tools and applying the same property on Pulldasher

---

Closes https://github.com/iFixit/pulldasher/issues/388