### PR TITLE
Default draft pulls toggle to off

### DIFF
--- a/frontend/src/navbar.tsx
+++ b/frontend/src/navbar.tsx
@@ -57,7 +57,7 @@ export function Navbar(props: NavBarProps) {
     "external_block",
     true
   );
-  const [showDrafts, toggleShowDrafts] = useBoolUrlState("drafts", true);
+  const [showDrafts, toggleShowDrafts] = useBoolUrlState("drafts", false);
   const [showPersonalView , togglePersonalView] = useBoolUrlState("personal", false);
   const hideBelowMedium = ["none", "none", "block"];
   const hideBelowLarge = ["none", "none", "none", "block"];


### PR DESCRIPTION
The main functionality change is setting the draft pulls toggle to default to the 'off' position. This ensures that draft pulls are hidden by default when a user visits Pulldasher.