### PR TITLE
Pulldasher: Update QA Column Filtering

### DIFF
--- a/frontend/src/pulldasher/index.tsx
+++ b/frontend/src/pulldasher/index.tsx
@@ -48,6 +48,7 @@ function Pulldasher() {
       !pull.isQaDone() &&
       !pull.getDevBlock() &&
       !pull.isDraft() &&
+      !pull.hasMergeConflicts() &&
       pull.hasPassedCI()
   );
   const leadersCR = getLeaders(allPulls, (pull) => pull.status.allCR);


### PR DESCRIPTION
### Overview:

Pulls that have merge conflicts will no longer show up in the QA column on Pulldasher.

Closes https://github.com/iFixit/pulldasher/issues/396