### PR TITLE
Feat: Add ignored statuses

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -74,6 +74,7 @@ module.exports = {
     {
       name: "owner/otherRepo",
       requiredStatuses: ["tests", "build", "codeClimate"],
+      ignoredStatuses: ["coverage"],
     },
   ],
 

--- a/frontend/src/pull.ts
+++ b/frontend/src/pull.ts
@@ -192,8 +192,16 @@ export class Pull extends PullData {
     return (
       this.repoSpec?.requiredStatuses ??
       // If there are no required statuses, then all existing statuses
-      // are required to be passing
-      this.buildStatuses().map((status) => status.data.context)
+      // are required to be passing unless they are ignored.
+      this.getBuildStatusesWithoutIgnored()
+    );
+  }
+
+  getBuildStatusesWithoutIgnored(): string[] {
+    return this.buildStatuses()
+      .map((status) => status.data.context)
+      .filter((context) =>
+        !this.repoSpec?.ignoredStatuses?.includes(context)
     );
   }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,7 +30,8 @@ export interface SignatureUser {
 }
 
 export interface RepoSpec {
-  requiredStatuses: string[];
+  requiredStatuses?: string[];
+  ignoredStatuses?: string[];
   name: string;
 }
 


### PR DESCRIPTION
We previously could only set `requiredStatuses`. This is great if all ci checks run
on every PR. We want to conditionally run different workflows on different PRs, so
we can't make certain statuses requried.

Instead, let's create a new `ignoredStatuses` that the user can set so that pulldasher
ignores those even if they are failing. 

QA:
--
We should verify that ignored statuses don't affect the ci blocked PRs. You can modify
`/mnt/ebs/etc/pulldasher-dev.config.js` and update pulldasher dev to make sure the
correct pulls are in (or out) of the CI Blocked column on pulldasher-dev.cominor.com.

Connects: https://github.com/iFixit/ifixit/issues/52034

cc @danielbeardsley 