### PR TITLE
DB: fix DB connection and query format 

### DIFF
--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -558,7 +558,7 @@ var dbManager = (module.exports = {
    */
   deleteLabels: function deleteLabels(repo, number) {
     debug("Calling deleteLabels for pull #%s in repo %s", number, repo);
-    var q_delete = "DELETE FROM pull_labels WHERE number = ? " + "AND repo = ?";
+    var q_delete = "DELETE FROM pull_labels WHERE number = ? AND repo = ?";
     return db.query(q_delete, [number, repo]);
   },
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,6 +1,14 @@
-var mysql = require("mysql2"),
-  config = require("./config-loader"),
-  Promise = require("bluebird");
+var mysql = require("mysql2/promise"),
+   config = require("./config-loader");
+
+// OMG, this took forever to figure out
+// Add support for understanding utf8mb3 charset to the mysql2 library
+// https://github.com/sidorares/node-mysql2/issues/1398
+// We don't have any utf8mb3 columns, but if you run a query that generates
+// no result (DELETE, REPLACE, ...) it will return metadata indicating that the
+// empty result is in the "servers" charset, which is utf8mb3 (still)
+var EncodingToCharset = require("../node_modules/mysql2/lib/constants/encoding_charset");
+EncodingToCharset.utf8mb3 = 192;
 
 const pool = mysql.createPool({
   host: config.mysql.host,
@@ -10,6 +18,9 @@ const pool = mysql.createPool({
   charset: "utf8mb4",
 });
 
-pool.query = Promise.promisify(pool.query);
-
-module.exports = pool;
+module.exports = {
+   query: function(query, params) {
+      return pool.query(query, params)
+         .then((result) => result[0]); // [rows, fields]
+   }
+};


### PR DESCRIPTION
Pulldasher was totally broken and would boot until it ran a `REPLACE INTO` query and then crash.

oof, see the second change.

First: The .query().then() was just changed to make use of the new
promise interface instead of promisifying the old callback interface.
It wasn't the problem.

Second: Add support for utf8mb3 to the library (we'll open a pull to add
it upstream). See the code comment.