### PR TITLE
Add ETag conditional-request cache to cut GitHub API usage

### DIFF
--- a/lib/etag-cache.js
+++ b/lib/etag-cache.js
@@ -1,0 +1,65 @@
+import debug from "./debug.js";
+
+const cacheDebug = debug("pulldasher:etag-cache");
+
+/**
+ * Installs an in-process ETag cache on an Octokit instance.
+ *
+ * GitHub does not count a conditional request against the primary rate limit
+ * when it returns `304 Not Modified`. By remembering the `ETag` of every GET
+ * response and replaying it via `If-None-Match`, unchanged resources cost no
+ * quota. This matters most at startup, where `refresh.openPulls()` re-fetches
+ * every open pull even though almost none have changed since the last run.
+ *
+ * See: https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api
+ *
+ * The cache is a bounded, insertion-ordered Map used as a rough LRU: touching
+ * an entry (on hit or refresh) moves it to the end, and the oldest entry is
+ * evicted once `maxEntries` is exceeded. It caches GETs only; other methods
+ * pass straight through.
+ */
+export default function installEtagCache(octokit, { maxEntries = 2000 } = {}) {
+  const cache = new Map();
+
+  function touch(key, value) {
+    // Re-insert so the entry counts as most-recently-used.
+    cache.delete(key);
+    cache.set(key, value);
+    while (cache.size > maxEntries) {
+      cache.delete(cache.keys().next().value);
+    }
+  }
+
+  octokit.hook.wrap("request", async (request, options) => {
+    if ((options.method || "GET").toUpperCase() !== "GET") {
+      return request(options);
+    }
+
+    // Resolve the full path + query string so paginated pages key separately.
+    const { method, url } = octokit.request.endpoint(options);
+    const key = `${method} ${url}`;
+    const cached = cache.get(key);
+
+    if (cached) {
+      options.headers = { ...options.headers, "if-none-match": cached.etag };
+    }
+
+    try {
+      const response = await request(options);
+      const etag = response.headers && response.headers.etag;
+      if (etag) {
+        touch(key, { etag, response });
+      }
+      return response;
+    } catch (error) {
+      if (error.status === 304 && cached) {
+        cacheDebug("304 hit: %s", key);
+        touch(key, cached);
+        return cached.response;
+      }
+      throw error;
+    }
+  });
+
+  return cache;
+}

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -1,5 +1,6 @@
 import { Octokit } from "@octokit/rest";
 import { throttling } from "@octokit/plugin-throttling";
+import installEtagCache from "./etag-cache.js";
 import config from "./config-loader.js";
 import Promise from "bluebird";
 import _ from "underscore";
@@ -47,6 +48,10 @@ const github = new MyOctokit({
     },
   },
 });
+
+// Replay ETags via If-None-Match so unchanged resources return 304 and don't
+// count against the primary rate limit. See lib/etag-cache.js.
+installEtagCache(github);
 
 const githubRest = github.rest;
 

--- a/test/etag-cache.test.js
+++ b/test/etag-cache.test.js
@@ -1,0 +1,83 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Octokit } from "@octokit/rest";
+import installEtagCache from "../lib/etag-cache.js";
+
+/**
+ * Builds an Octokit whose network layer is a stub `fetch`, plus a log of the
+ * requests it saw, so we can assert on conditional-request behavior without
+ * hitting the network.
+ */
+function octokitWithFakeFetch(responder) {
+  const requests = [];
+  const fetch = async (url, options) => {
+    requests.push({ url, method: options.method, headers: options.headers });
+    return responder(url, options, requests.length);
+  };
+  const octokit = new Octokit({ auth: "test-token", request: { fetch } });
+  installEtagCache(octokit);
+  return { octokit, requests };
+}
+
+function json(data, { status = 200, etag } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (etag) {
+    headers.etag = etag;
+  }
+  return new Response(status === 304 ? null : JSON.stringify(data), {
+    status,
+    headers,
+  });
+}
+
+test("replays the cached body when GitHub returns 304", async () => {
+  const body = [{ id: 1, title: "first" }];
+  const { octokit, requests } = octokitWithFakeFetch((url, options, n) =>
+    n === 1
+      ? json(body, { etag: '"abc"' })
+      : json(null, { status: 304, etag: '"abc"' })
+  );
+
+  const first = await octokit.request("GET /repos/{o}/{r}/pulls", {
+    o: "iFixit",
+    r: "pulldasher",
+  });
+  const second = await octokit.request("GET /repos/{o}/{r}/pulls", {
+    o: "iFixit",
+    r: "pulldasher",
+  });
+
+  assert.deepEqual(second.data, body, "304 response serves the cached body");
+  assert.deepEqual(first.data, second.data);
+  assert.equal(requests.length, 2, "second request still hits the network");
+  assert.equal(
+    requests[0].headers["if-none-match"],
+    undefined,
+    "first request sends no conditional header"
+  );
+  assert.equal(
+    requests[1].headers["if-none-match"],
+    '"abc"',
+    "second request replays the cached ETag"
+  );
+});
+
+test("does not send a conditional header for non-GET requests", async () => {
+  const { octokit, requests } = octokitWithFakeFetch(() =>
+    json({ ok: true }, { etag: '"xyz"' })
+  );
+
+  await octokit.request("POST /repos/{o}/{r}/issues", {
+    o: "iFixit",
+    r: "pulldasher",
+    title: "hi",
+  });
+  await octokit.request("POST /repos/{o}/{r}/issues", {
+    o: "iFixit",
+    r: "pulldasher",
+    title: "hi",
+  });
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].headers["if-none-match"], undefined);
+});


### PR DESCRIPTION
Draft for option 1 in #467.

## What

Adds an in-process **ETag conditional-request cache** to the Octokit client. A conditional request returning `304 Not Modified` does **not** count against the primary REST rate limit ([docs](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api)). `lib/etag-cache.js` wraps the Octokit `request` hook to:

- remember each GET response's `ETag`,
- replay it via `If-None-Match` on the next identical request,
- serve the cached body when GitHub responds `304`.

## Why

On boot, `app.js` runs `refresh.openPulls()`, sending every open pull (across all repos) through `git-manager.parse()` — ~8–15 REST calls each. Almost none have changed since the last run, so on a restart this re-fetch is mostly wasted quota and can blow the 5000/hr limit (the incident in #467). With the cache, unchanged resources return `304` and cost nothing.

## How

- `installEtagCache(octokit)` is called once in `git-manager.js`, right after the client is built (composes with the existing throttling plugin).
- GETs only; other methods pass through untouched.
- Bounded, insertion-ordered `Map` used as a rough LRU (default 2000 entries), keyed by the resolved `method + url` so paginated pages cache separately.

## Test plan

- [x] `node --test test/*.test.js` — new `test/etag-cache.test.js` drives a real Octokit with a stub `fetch`, asserting the 200→304 replay path and that the cached `ETag` is sent via `If-None-Match`; non-GETs send no conditional header.
- [x] `npx eslint` on changed files — clean.
- [ ] Manual: deploy, restart, confirm open-pull resync produces `304`s (debug `pulldasher:etag-cache`) and that `core` rate-limit usage drops vs. a cold start.

## Notes / open questions for #467

- Cache is process-local and lost on restart — the first post-restart fetch still spends quota once (then 304s thereafter). A persistent store (Redis) would survive restarts; probably overkill, worth a sentence in #467.
- `maxEntries` default 2000 is a guess; size to open-pull count × endpoints-per-pull.
- Does not change `getAllJobRuns` (#467 item 2) — that's the next lever.
