### PR TITLE
Honor GitHub approvals carried over a clean master merge

### DIFF
--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -62,6 +62,9 @@ const HooksController = {
       // Promise that resolves when everything that needs to be done before
       // we call `updatePull` has finished.
       var preUpdate = handleLabelEvents(body);
+      // New commits may carry a GitHub approval over a clean master merge, so
+      // after the cheap DB update we re-derive review state from GitHub.
+      var reconcileAfterUpdate = false;
 
       switch (body.action) {
         case "opened":
@@ -72,17 +75,33 @@ const HooksController = {
           break;
 
         case "synchronize":
+          // Clear prior CR/QA signoffs immediately for snappy feedback. Emoji
+          // CR/QA stay cleared; a carried-over GitHub *approval* is restored by
+          // the full refresh below (see Signature.parseReview / git-manager).
           preUpdate = dbManager.invalidateSignatures(
             body.repository.full_name,
             body.pull_request.number,
             ["QA", "CR"]
           );
+          reconcileAfterUpdate = true;
       }
 
       // Update DB with new pull request content.
-      dbUpdated = preUpdate.then(function () {
-        return dbManager.updatePull(Pull.fromGithubApi(body.pull_request));
-      });
+      dbUpdated = preUpdate
+        .then(function () {
+          return dbManager.updatePull(Pull.fromGithubApi(body.pull_request));
+        })
+        .then(function () {
+          // A `synchronize` webhook never triggers a full refresh on its own,
+          // and Pulldasher has no periodic poll, so re-derive here to pick up
+          // an approval GitHub kept across the new commit(s).
+          if (reconcileAfterUpdate) {
+            return refresh.pull(
+              body.repository.full_name,
+              body.pull_request.number
+            );
+          }
+        });
     } else if (event === "issue_comment") {
       if (body.action === "created") {
         var promises = [];

--- a/lib/git-manager.js
+++ b/lib/git-manager.js
@@ -199,10 +199,19 @@ export default {
       }, commentSignatures);
 
       // Signoffs from before the most recent commit are no longer active.
+      //
+      // Exception: a CR derived from a GitHub native "Approve" review. GitHub
+      // carries an approval over a clean master merge (it dismisses the review
+      // only when the diff actually changes), so its `submitted_at` legitimately
+      // predates the merge commit. GitHub is the source of truth here: if the
+      // review is still APPROVED at refresh time, parseReview synthesized this
+      // signature, which means the approval is still valid. Re-applying the
+      // commit-date check would drop approvals GitHub deliberately kept.
       var headCommitDate = new Date(headCommit.commit.committer.date);
       signatures.forEach(function (signature) {
         if (
           (signature.data.type === "CR" || signature.data.type === "QA") &&
+          !signature.data.fromGithubApproval &&
           new Date(signature.data.created_at) < headCommitDate
         ) {
           signature.data.active = false;

--- a/models/signature.js
+++ b/models/signature.js
@@ -18,6 +18,12 @@ function Signature(data) {
     created_at: utils.fromDateString(data.created_at),
     active: data.active,
     comment_id: data.comment_id,
+    // True only for a CR signature synthesized from a GitHub native
+    // "Approve" review (not an emoji `CR` tag). GitHub is the source of
+    // truth for whether such an approval is still valid, so it is exempt
+    // from the "stale after the last commit" check (see git-manager).
+    // In-memory only; not persisted to the DB.
+    fromGithubApproval: data.fromGithubApproval === true,
   };
 }
 
@@ -75,6 +81,7 @@ Signature.parseReview = function parseReview(review, repoFullName, pullNumber) {
         created_at: review.submitted_at,
         active: true,
         comment_id: review.id,
+        fromGithubApproval: true,
       })
     );
   }

--- a/test/signature.test.js
+++ b/test/signature.test.js
@@ -26,6 +26,9 @@ test("parseReview creates CR signature from APPROVED review with empty body", ()
   assert.equal(signatures[0].data.type, "CR");
   assert.equal(signatures[0].data.comment_id, 100);
   assert.equal(signatures[0].data.user.login, "reviewer");
+  // Flagged so git-manager exempts it from the commit-date staleness check,
+  // letting an approval carry over a clean master merge.
+  assert.equal(signatures[0].data.fromGithubApproval, true);
 });
 
 test("parseReview keeps single CR signature when body already contains CR tag", () => {
@@ -43,6 +46,9 @@ test("parseReview keeps single CR signature when body already contains CR tag", 
 
   assert.equal(signatures.length, 1);
   assert.equal(signatures[0].data.type, "CR");
+  // The CR came from the emoji tag, not the native approval, so it is NOT
+  // exempt from the staleness check — new commits should still invalidate it.
+  assert.equal(signatures[0].data.fromGithubApproval, false);
 });
 
 test("parseReview ignores CHANGES_REQUESTED reviews", () => {


### PR DESCRIPTION
## Summary
Follow-up to #463. A GitHub native **Approve** review (now mapped to a CR signoff) **carries over a clean master merge** — GitHub only dismisses the review when the diff actually changes. Pulldasher dropped the CR anyway, so GitHub showed the PR approved while the Pulldasher CR bubble was empty.

## Root cause
Two paths killed the carried-over approval:

1. **`lib/git-manager.js`** — the full refresh marks any CR/QA whose timestamp predates the head commit inactive. An approval's `submitted_at` legitimately predates a later merge commit, so every refresh re-killed it.
2. **`controllers/githubHooks.js` (`synchronize`)** — a master merge fires only `synchronize`, which blanket-invalidated CR/QA and **never re-derived** review state. With no periodic poll (only startup `refresh.openPulls`), the approval stayed dropped until restart.

## Fix
- Tag the synthesized approval CR with `fromGithubApproval` (`models/signature.js`), in-memory only — not persisted.
- Exempt those signatures from the commit-date staleness check (`lib/git-manager.js`). GitHub is the source of truth: if the review is still `APPROVED` at refresh time, the approval is valid; if a commit should kill it, GitHub returns a non-`APPROVED` state and `parseReview` synthesizes no CR.
- After the `synchronize` invalidate, run a full `refresh.pull` to re-derive review state (`controllers/githubHooks.js`). The immediate invalidate stays for snappy UI; the refresh refills only the still-valid approval.

## Tradeoff
One extra full refresh per push per tracked PR. The ETag cache makes these mostly `304`s, so no rate-limit hit.

## Known edge (unchanged)
A reviewer who *both* approves natively *and* writes `CR :emoji:` → dedup keeps the emoji CR (not exempt), so it still invalidates on merge. Pre-existing dedup behavior, left as-is.

## Test plan
- [x] `npm test` — asserts `fromGithubApproval` true for native approval, false for emoji CR
- [x] `npm run lint`
- [ ] Manual: approve a PR on GitHub, merge master cleanly into the branch, confirm the CR bubble stays filled in Pulldasher
- [ ] Manual: push a real code change after approval, confirm GitHub dismisses and the CR bubble drops