### PR TITLE
fix: stop synchronize refresh from wedging the pull queue

### DIFF
--- a/controllers/githubHooks.js
+++ b/controllers/githubHooks.js
@@ -87,21 +87,24 @@ const HooksController = {
       }
 
       // Update DB with new pull request content.
-      dbUpdated = preUpdate
-        .then(function () {
-          return dbManager.updatePull(Pull.fromGithubApi(body.pull_request));
-        })
-        .then(function () {
-          // A `synchronize` webhook never triggers a full refresh on its own,
-          // and Pulldasher has no periodic poll, so re-derive here to pick up
-          // an approval GitHub kept across the new commit(s).
-          if (reconcileAfterUpdate) {
-            return refresh.pull(
-              body.repository.full_name,
-              body.pull_request.number
-            );
-          }
+      dbUpdated = preUpdate.then(function () {
+        return dbManager.updatePull(Pull.fromGithubApi(body.pull_request));
+      });
+
+      if (reconcileAfterUpdate) {
+        // A `synchronize` webhook never triggers a full refresh on its own,
+        // and Pulldasher has no periodic poll, so re-derive review state from
+        // GitHub once the cheap DB update lands to pick up an approval GitHub
+        // kept across the new commit(s).
+        //
+        // Fire-and-forget, like every other refresh.pull caller below. Do NOT
+        // fold it into `dbUpdated`: coupling the webhook's HTTP response to a
+        // full, serialized refresh risks GitHub's 10s webhook timeout and
+        // turns a transient refresh failure into a 500 + redelivery storm.
+        dbUpdated.then(function () {
+          refresh.pull(body.repository.full_name, body.pull_request.number);
         });
+      }
     } else if (event === "issue_comment") {
       if (body.action === "created") {
         var promises = [];

--- a/lib/db-manager.js
+++ b/lib/db-manager.js
@@ -80,8 +80,14 @@ const dbManager = {
 
       return Promise.all(updates).then(function () {
         queue.markPullAsDirty(pull.data.repo, pull.data.number);
-        queue.resume();
       });
+    }).finally(function () {
+      // Always resume the queue, even if a DB write above rejected. Resuming
+      // only on success would leave the queue paused forever after a single
+      // failed write, silently swallowing every later pull update (merges,
+      // closes included) and freezing the dashboard until a manual refresh
+      // happens to resume it.
+      queue.resume();
     });
   },
 

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -122,8 +122,20 @@ pullQueue.pop(function (githubPull, next) {
   gitManager
     .parse(githubPull)
     .then(dbManager.updateAllPullData)
-    .done(function () {
+    .then(function () {
       refreshDebug("done refreshing pull %s", githubPull.number);
-      next();
-    });
+    })
+    .catch(function (err) {
+      // A failed refresh must not stall the queue. Log and fall through so
+      // `next()` still runs below; otherwise the queue's resolve thunk is
+      // never popped, any refresh.pull() awaiting this item never settles,
+      // and every subsequent refresh hangs behind it.
+      console.error(
+        "Error refreshing pull %s in repo %s:",
+        githubPull.number,
+        githubPull.base.repo.full_name,
+        err
+      );
+    })
+    .done(next);
 });


### PR DESCRIPTION
Fixes #470.

#469 routed every `synchronize` webhook through a full `refresh.pull`, awaited inside the webhook response and processed by a one-at-a-time queue whose error handling could leave the dashboard frozen until a PR was manually refreshed (the "Pulldasher is very out of date" report). The merge/close logic itself was never broken — the queue wedged.

### Changes

**1. `updateAllPullData` always resumes the queue** (`lib/db-manager.js`)
`queue.resume()` moved into `.finally()`. It previously ran only on success, so one rejected DB write left the pull-queue paused forever. While paused, `markPullAsDirty` silently stashes into `dirtyPulls` and emits nothing (`lib/pull-queue.js:17-24`) — every later pull update (merges/closes) is swallowed and the board freezes until something happens to resume it. Pre-existing latent bug (since 2016); #469 made it live by sending every push through this path.

**2. Refresh queue pop can't stall** (`lib/refresh.js`)
Bare `.done(onFulfilled)` → `.then().catch(log).done(next)`. A failed `parse`/`updateAllPullData` now logs and still calls `next()`. Previously a rejection skipped `next()`, so the queue's resolve thunk was never popped, any `refresh.pull()` awaiting the item never settled, and the webhook hung to GitHub's 10s timeout — stalling all later refreshes behind it.

**3. Synchronize reconcile is fire-and-forget** (`controllers/githubHooks.js`)
The reconcile `refresh.pull` is no longer folded into `dbUpdated`. The webhook 200 returns after the cheap `updatePull`; the full refresh runs in the background, matching every other `refresh.pull` caller. Stops coupling the HTTP response to a serialized full refresh — which risked the 10s webhook timeout and turned transient refresh failures into 500s + redeliveries.

Items 1-2 are pre-existing latent bugs #469 turned live; 3 is #469-specific.

### Not addressed here
Item 4 from #470 — confirm branch protection "Dismiss stale pull request approvals when new commits are pushed" is enabled on tracked repos (or add a commit-since-approval check). That's repo config, not code; tracked in the issue.

### Verification
- `npm test` — 3/3 pass (`test/signature.test.js`).
- `eslint` clean on all three changed files.
