### PR TITLE
Post-launch cleanup: search all PRs, review lanes, bots, notifications

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -93,8 +93,11 @@ module.exports = {
    // socket, and read by the /api/v1 endpoint. Both are optional.
    //
    // Bot logins beyond the `[bot]` suffix GitHub Apps carry (so pulldasher can
-   // fold/skip their PRs). Omit or [] for suffix-only detection.
-   bots: ['renovate-bot'],
+   // fold/skip their PRs). Omit or [] for suffix-only detection. ifixit-systems
+   // is our dependency-bumper and AI-agent account; Copilot is GitHub's coding
+   // agent (type Bot, no [bot] suffix). claude[bot] and the other suffixed apps
+   // are already detected without listing.
+   bots: ['renovate-bot', 'ifixit-systems', 'Copilot'],
    // Label title -> review-weight bucket (XS|S|M|L|XL). A PR carrying one of
    // these labels takes that weight instead of the diff-size guess, so an auto
    // weight label (and any manual override) drives the board and the API. Omit

--- a/frontend-v2/src/app.tsx
+++ b/frontend-v2/src/app.tsx
@@ -47,6 +47,7 @@ import { Team } from './views/Team';
 import { Classic } from './views/Classic';
 import { Ci } from './views/Ci';
 import { Stats } from './views/Stats';
+import { Search } from './views/Search';
 import { Settings } from './components/Settings';
 
 export type { Lens };
@@ -264,6 +265,10 @@ export function App() {
    const [scope, setScope] = useScope();
    const [lens, setLens] = useState<Lens>(() => readHash().lens);
    const [query, setQuery] = useState(() => urlState.q);
+   // free text is find, not filter: any query switches the board to the Search
+   // lens (global, over open + closed), so the header box stops narrowing the
+   // current lens and starts finding across the whole board
+   const searching = query.trim().length > 0;
    // narrows the board to one or more review-effort classes ('xs'..'xl',
    // 'unknown'); empty = no filter
    const [weightSel, setWeightSel] = useState<string[]>(() => urlState.weight);
@@ -711,10 +716,17 @@ export function App() {
 
    // an avatar click anywhere lands on that person's board: their login
    // becomes the authors scope (visible in the bar, clearable there too)
+   // a user picking a lens leaves search: clear the query so the chosen lens
+   // actually renders (a lingering query keeps the Search lens up)
+   const goToLens = useCallback((id: Lens) => {
+      setQuery('');
+      setLens(id);
+   }, []);
    // and the Team lens shows the result
    const onPerson = useCallback(
       (login: string) => {
          setScope({ ...scope, authors: [login], notAuthors: [] });
+         setQuery('');
          setLens('team');
       },
       [scope, setScope]
@@ -771,11 +783,13 @@ export function App() {
    const tab = (id: Lens, label: string, count?: number) => (
       <button
          type="button"
-         aria-current={lens === id ? 'page' : undefined}
+         aria-current={lens === id && !searching ? 'page' : undefined}
          aria-label={count ? `${label}, ${count} of yours open` : undefined}
-         onClick={() => setLens(id)}
+         onClick={() => goToLens(id)}
          className={`pressable relative shrink-0 rounded-lg border-0 px-3 py-2 text-sm font-medium whitespace-nowrap ${
-            lens === id ? 'bg-secondary text-ink' : 'bg-transparent text-ink-2 hover:text-brand'
+            lens === id && !searching
+               ? 'bg-secondary text-ink'
+               : 'bg-transparent text-ink-2 hover:text-brand'
          }`}
       >
          {label}
@@ -844,6 +858,7 @@ export function App() {
    // the quick-wins toast filters the board to the small reviewable ones on the
    // review lens, instead of scrolling to just the first of the batch
    const onQuickWins = useCallback(() => {
+      setQuery('');
       setLens('review');
       setWeightSel(['XS', 'S']);
    }, []);
@@ -984,7 +999,7 @@ export function App() {
                   <span className="hidden sm:flex">
                      <Legend />
                   </span>
-                  <Settings onGoToTeam={() => setLens('team')} />
+                  <Settings onGoToTeam={() => goToLens('team')} />
                </div>
                <div className="mx-auto flex max-w-[1240px] min-w-0 items-center px-5 py-2.5 pl-11 pr-32 sm:pr-40 2xl:px-5">
                   {/* min-w-0 + overflow-x-auto (no-scrollbar in styles.css)
@@ -1008,7 +1023,7 @@ export function App() {
                   <LensMenu
                      className="sm:hidden"
                      lens={lens}
-                     setLens={setLens}
+                     setLens={goToLens}
                      options={LENSES.map(id => ({
                         id,
                         label: LENS_LABELS[id],
@@ -1112,8 +1127,8 @@ export function App() {
                   sessionActive={sessionActive}
                   inputProps={{
                      'aria-label':
-                        'Filter PRs: text, #number, label:x, status:x, older:5, repo:x, author:x, weight:xs, has:action, is:draft, is:mine, is:restamp, is:blocked, is:bot',
-                     placeholder: 'Filter (press /)',
+                        'Search all PRs, open and closed: text, #number, label:x, status:x, older:5, repo:x, author:x, weight:xs, has:action, is:draft, is:mine, is:restamp, is:blocked, is:bot',
+                     placeholder: 'Search all PRs (press /)',
                      title: 'text, #number, label:x, status:x, older:5, repo:x, author:x, weight:xs, has:action, is:draft, is:mine, is:restamp, is:blocked, is:bot',
                      className: `w-[210px] max-w-full grow pr-2.5 pl-8 sm:grow-0 ${textInputClass}`,
                   }}
@@ -1153,7 +1168,20 @@ export function App() {
                   <span className="text-sm">Loading the board…</span>
                </div>
             )}
-            {initialized && lens === 'review' && (
+            {/* free text is a find, not a filter: while there's a query the
+                board becomes the global Search lens (open + closed, every lens,
+                nothing folded), regardless of which tab was active */}
+            {initialized && searching && (
+               <Search
+                  pulls={pulls}
+                  closed={closed}
+                  query={query}
+                  opts={rowOpts}
+                  extraBots={extraBots}
+                  names={names}
+               />
+            )}
+            {initialized && !searching && lens === 'review' && (
                <Review
                   pulls={humans}
                   bots={bots}
@@ -1162,10 +1190,10 @@ export function App() {
                   opts={{ ...rowOpts, showSnooze: true }}
                />
             )}
-            {initialized && lens === 'mine' && (
+            {initialized && !searching && lens === 'mine' && (
                <MyWork pulls={humans} closed={closed} opts={rowOpts} />
             )}
-            {initialized && lens === 'team' && (
+            {initialized && !searching && lens === 'team' && (
                <Team
                   pulls={humans}
                   allPulls={pulls.filter(p => !isBot(p))}
@@ -1175,9 +1203,11 @@ export function App() {
                   extraBots={extraBots}
                />
             )}
-            {initialized && lens === 'classic' && <Classic pulls={scoped} opts={rowOpts} />}
-            {initialized && lens === 'ci' && <Ci pulls={ciPulls} opts={rowOpts} />}
-            {initialized && lens === 'stats' && (
+            {initialized && !searching && lens === 'classic' && (
+               <Classic pulls={scoped} opts={rowOpts} />
+            )}
+            {initialized && !searching && lens === 'ci' && <Ci pulls={ciPulls} opts={rowOpts} />}
+            {initialized && !searching && lens === 'stats' && (
                <Stats pulls={humans} closed={closed} me={me} onPerson={onPerson} />
             )}
          </main>

--- a/frontend-v2/src/app.tsx
+++ b/frontend-v2/src/app.tsx
@@ -929,35 +929,44 @@ export function App() {
                   />
                </div>
             </div>
-            <div className="mx-auto flex max-w-[1240px] min-w-0 flex-wrap items-center gap-2 border-t border-secondary px-5 py-2">
-               {/* pinned saved searches, FIRST in the bar so a growing
-                   trigger can never displace them: every roster earns one
-                   automatically (kept in sync with its members), and any
-                   search can be pinned from the Saved menu. Click applies
-                   it on the lens you're standing on; click again clears.
-                   State is carried entirely by color — the chip's text
-                   never changes, so nothing ever shifts. */}
-               {pinnedSearches.map(f => {
-                  const active = matchesView(f.hash, currentHash);
-                  const title = active
-                     ? `showing ${f.name}: click to clear`
-                     : `show ${f.name}: ${describeHash(f.hash)}`;
-                  return (
-                     <button
-                        key={(f.auto ? 'team:' : 'saved:') + f.name}
-                        type="button"
-                        aria-pressed={active}
-                        title={title}
-                        aria-label={title}
-                        onClick={() => applySavedFilter(active ? '' : f.hash)}
-                        className={`hit pressable inline-flex max-w-[160px] items-center rounded-md px-1.5 py-1 text-[13px] ${
-                           active ? 'bg-secondary text-ink' : 'text-ink-3 hover:text-ink'
-                        }`}
-                     >
-                        <span className="truncate">{f.name}</span>
-                     </button>
-                  );
-               })}
+            {/* Pinned saved searches get their own line. Reviewers deliberately
+                pin many (every roster earns one automatically, plus hand-saved
+                ones), which overflowed the shared trigger row into a wall. A
+                dedicated horizontally-scrollable strip keeps every pin one click
+                away and stops a growing set from wrapping the dimension triggers
+                below. Click applies it on the lens you're standing on; click
+                again clears. State is a background tint; the text never changes,
+                so nothing shifts. */}
+            {pinnedSearches.length > 0 && (
+               <div className="no-scrollbar mx-auto flex max-w-[1240px] min-w-0 items-center gap-2 overflow-x-auto border-t border-secondary px-5 py-2">
+                  {pinnedSearches.map(f => {
+                     const active = matchesView(f.hash, currentHash);
+                     const title = active
+                        ? `showing ${f.name}: click to clear`
+                        : `show ${f.name}: ${describeHash(f.hash)}`;
+                     return (
+                        <button
+                           key={(f.auto ? 'team:' : 'saved:') + f.name}
+                           type="button"
+                           aria-pressed={active}
+                           title={title}
+                           aria-label={title}
+                           onClick={() => applySavedFilter(active ? '' : f.hash)}
+                           className={`hit pressable inline-flex max-w-[160px] shrink-0 items-center rounded-md px-1.5 py-1 text-[13px] ${
+                              active ? 'bg-secondary text-ink' : 'text-ink-3 hover:text-ink'
+                           }`}
+                        >
+                           <span className="truncate">{f.name}</span>
+                        </button>
+                     );
+                  })}
+               </div>
+            )}
+            <div
+               className={`mx-auto flex max-w-[1240px] min-w-0 flex-wrap items-center gap-2 px-5 py-2 ${
+                  pinnedSearches.length > 0 ? '' : 'border-t border-secondary'
+               }`}
+            >
                <RepoFilter
                   repos={repoCounts}
                   reveal={reveal}

--- a/frontend-v2/src/app.tsx
+++ b/frontend-v2/src/app.tsx
@@ -16,7 +16,6 @@ import { useBoardHotkeys, useHeaderHeightVar } from './hooks';
 import { ageRotDays, getSettings, type Settings as SettingsShape, useSettings } from './settings';
 import { useNotifications } from './notifications';
 import { ToastStack, useToasts } from './toasts';
-import { matchesQuery } from './model/query';
 import { requestNames, useNames } from './model/names';
 import { CRYO_KEY, isBotLogin, personHidden, repoHidden } from '../../shared/model/visibility';
 import { reviewRequestedFrom } from './model/reviewers';
@@ -547,10 +546,13 @@ export function App() {
    // settings above), not the current filter
    useNotifications(nudgeablePulls, me, turns, initialized);
 
-   // every existing scope/query pass, but not yet the Weight/State filters —
-   // WeightFilter's live per-option counts read this pool, so narrowing to
-   // one weight class doesn't make the other classes' counts vanish (the
-   // same reasoning PeopleFilter's authorCounts follows for its own pool)
+   // scope + hidden, but deliberately NOT free text: a query drives the global
+   // Search lens (App renders <Search> instead of the current lens), so
+   // filtering the whole board by it here would recompute every keystroke only
+   // to feed a view that never shows while searching. Also not the Weight/State
+   // filters yet: WeightFilter's live per-option counts read this pool, so
+   // narrowing to one weight class doesn't make the other classes' counts
+   // vanish (the same reasoning PeopleFilter's authorCounts follows).
    const preWeightScoped = useMemo(() => {
       let out = pulls.filter(p => !boardHidden(p));
       if (scope.repos.length) out = out.filter(p => scope.repos.includes(p.data.repo));
@@ -562,9 +564,8 @@ export function App() {
       // allow-list above (a dependency bump is nobody's teammate)
       if (scope.notAuthors.length)
          out = out.filter(p => isBot(p) || !scope.notAuthors.includes(p.data.user.login));
-      if (query) out = out.filter(p => matchesQuery(p, query, me, extraBots, names));
       return out;
-   }, [pulls, boardHidden, scope, isBot, query, names, me, extraBots]);
+   }, [pulls, boardHidden, scope, isBot]);
 
    // preWeightScoped narrowed by the Weight filter, but not yet State —
    // StateFilter's own live counts read this pool for the same
@@ -592,31 +593,20 @@ export function App() {
 
    // Bots that pass every hidden rule except "Ignore bot PRs": hidden
    // repos/people, cryo, and the drafts rule still apply, and the active
-   // repo scope / weight / state / query filters narrow it the same way
-   // they narrow `scoped` (scope.authors/notAuthors don't need repeating
-   // here — bots already bypass both in preWeightScoped above). Only the
-   // hideBots-specific exclusion is skipped. Feeds the CI lens and
-   // Ready-to-merge (below), the two surfaces that need bot signal
-   // regardless of hideBots.
+   // repo scope / weight / state filters narrow it the same way they narrow
+   // `scoped` (scope.authors/notAuthors don't need repeating here — bots
+   // already bypass both in preWeightScoped above). Free text is left out for
+   // the same reason as preWeightScoped: a query shows the Search lens, not
+   // this pool's CI/Ready surfaces. Only the hideBots-specific exclusion is
+   // skipped. Feeds the CI lens and Ready-to-merge (below), the two surfaces
+   // that need bot signal regardless of hideBots.
    const botsBypassingHideBots = useMemo(() => {
       let out = pulls.filter(p => isBot(p) && !boardHiddenExceptBots(p));
       if (scope.repos.length) out = out.filter(p => scope.repos.includes(p.data.repo));
-      if (query) out = out.filter(p => matchesQuery(p, query, me, extraBots, names));
       if (weightSel.length) out = out.filter(p => matchesWeightFilter(p, weightSel));
       if (stateSel.length) out = out.filter(p => stateSel.includes(actionState(p, me)));
       return out;
-   }, [
-      pulls,
-      isBot,
-      boardHiddenExceptBots,
-      scope.repos,
-      query,
-      me,
-      names,
-      extraBots,
-      weightSel,
-      stateSel,
-   ]);
+   }, [pulls, isBot, boardHiddenExceptBots, scope.repos, me, weightSel, stateSel]);
    // The CI lens's pool: `scoped` (which already respects hideBots, escape
    // hatch included) plus whatever bot the bypass pool above adds back —
    // deduped by key so a bot already visible in `scoped` (hideBots off, or
@@ -690,7 +680,9 @@ export function App() {
       return c;
    }, [pulls, me, settings.repoPrefs, settings.hiddenPeople, isBot, boardHidden]);
 
-   const isScoped = scope.repos.length || scope.authors.length || query;
+   // a query no longer scopes the board (it shows the Search lens instead), so
+   // the header's "X of Y" only reflects the repo/people filters
+   const isScoped = scope.repos.length || scope.authors.length;
 
    // what a "Save current filter…" click right now would capture — reads the
    // same hashState the write-effect above builds, so a saved filter's hash

--- a/frontend-v2/src/app.tsx
+++ b/frontend-v2/src/app.tsx
@@ -8,6 +8,7 @@ import { matchesWeightFilter } from '../../shared/model/status';
 import { buildParentLookup } from './model/stack';
 import { buildReviewerPools, turnFor } from './model/rotation';
 import { shipRelevance, shippedToast } from './model/shipped';
+import { notificationStale } from './model/notificationRelevance';
 import type { Toast } from './model/toast';
 import { claimReview, isSnoozed, usePulldasher } from './store';
 import { primeScope, useScope } from './prefs';
@@ -881,6 +882,23 @@ export function App() {
       snoozedKeys
    );
 
+   // A fired nudge outlives the PR it points at: once that PR merges or closes
+   // it drops off the board, so a bell entry like "return the favor on
+   // fixbot#3116" is left pointing at a dead link. Drop any panel record whose
+   // PR has left the open board -- notificationStale is general across every
+   // kind, and exempts the retrospective shipped recap and board-wide rewards.
+   // Keyed off the FULL board, not nudgeablePulls, so hiding a repo doesn't
+   // read as "done". Held until the first payload lands, or an empty pre-load
+   // board would blank the panel.
+   const openKeys = useMemo(() => new Set(pulls.map(p => pullKey(p.data))), [pulls]);
+   const liveHistory = useMemo(
+      () =>
+         initialized
+            ? toastHistory.filter(r => !notificationStale(r.toast, openKeys))
+            : toastHistory,
+      [toastHistory, openKeys, initialized]
+   );
+
    return (
       <>
          <ToastStack toasts={toasts} onDismiss={dismissToast} />
@@ -957,7 +975,7 @@ export function App() {
                      v1 board
                   </a>
                   <NotificationPanel
-                     records={toastHistory}
+                     records={liveHistory}
                      onClear={clearHistory}
                      onDismiss={dismissHistoryItem}
                   />

--- a/frontend-v2/src/app.tsx
+++ b/frontend-v2/src/app.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import {
+   useCallback,
+   useDeferredValue,
+   useEffect,
+   useMemo,
+   useRef,
+   useState,
+   type ReactNode,
+} from 'react';
 import { ago, closedEpoch, n, pullKey, shortRepo } from '../../shared/format';
 import type { ActionStateKey } from './model/actions';
 import { actionState } from './model/actions';
@@ -266,8 +274,20 @@ export function App() {
    const [query, setQuery] = useState(() => urlState.q);
    // free text is find, not filter: any query switches the board to the Search
    // lens (global, over open + closed), so the header box stops narrowing the
-   // current lens and starts finding across the whole board
-   const searching = query.trim().length > 0;
+   // current lens and starts finding across the whole board.
+   //
+   // The heavy part of a search is rendering the matched rows, and the first
+   // keystroke MOUNTS the Search view. useDeferredValue gives no deferral on a
+   // mount, so deferring inside Search left that first render synchronous, and a
+   // broad query (say "a") blocked the main thread ~350ms on the dummy board,
+   // more at prod scale, freezing the keystroke itself. Deferring the query HERE
+   // makes the view swap and its render a low-priority, time-sliced pass: the
+   // box updates urgently off `query`, the board keeps showing the current lens
+   // until the deferred render is ready, and React can interrupt a stale broad
+   // render when you keep typing. `stale` dims the results while it catches up.
+   const deferredQuery = useDeferredValue(query);
+   const searching = deferredQuery.trim().length > 0;
+   const searchStale = query !== deferredQuery;
    // narrows the board to one or more review-effort classes ('xs'..'xl',
    // 'unknown'); empty = no filter
    const [weightSel, setWeightSel] = useState<string[]>(() => urlState.weight);
@@ -1167,7 +1187,8 @@ export function App() {
                <Search
                   pulls={pulls}
                   closed={closed}
-                  query={query}
+                  query={deferredQuery}
+                  stale={searchStale}
                   opts={rowOpts}
                   extraBots={extraBots}
                   names={names}

--- a/frontend-v2/src/app.tsx
+++ b/frontend-v2/src/app.tsx
@@ -487,8 +487,10 @@ export function App() {
    // term, or the master "show everything". Never hides your own pulls; bots
    // hide only when you turn on Ignore bot PRs (they otherwise have their own
    // fold), and a person can't hide themselves. Shared by the filter pipeline and the
-   // hidden-PR ledger's counts so the ledger's number can never disagree
-   // with what the board actually withholds.
+   // hidden-PR ledger's counts so the ledger's number matches this predicate
+   // exactly — with one deliberate exception: the CI lens and Ready-to-merge
+   // read botsBypassingHideBots (below) instead of this function, so a bot
+   // PR the ledger counts as hidden by "Ignore bot PRs" can still show there.
    const boardHidden = useCallback(
       (p: DerivedPull) => {
          if (showAll) return false;
@@ -554,9 +556,9 @@ export function App() {
       // allow-list above (a dependency bump is nobody's teammate)
       if (scope.notAuthors.length)
          out = out.filter(p => isBot(p) || !scope.notAuthors.includes(p.data.user.login));
-      if (query) out = out.filter(p => matchesQuery(p, query, me, names));
+      if (query) out = out.filter(p => matchesQuery(p, query, me, extraBots, names));
       return out;
-   }, [pulls, boardHidden, scope, isBot, query, names, me]);
+   }, [pulls, boardHidden, scope, isBot, query, names, me, extraBots]);
 
    // preWeightScoped narrowed by the Weight filter, but not yet State —
    // StateFilter's own live counts read this pool for the same
@@ -593,11 +595,22 @@ export function App() {
    const botsBypassingHideBots = useMemo(() => {
       let out = pulls.filter(p => isBot(p) && !boardHiddenExceptBots(p));
       if (scope.repos.length) out = out.filter(p => scope.repos.includes(p.data.repo));
-      if (query) out = out.filter(p => matchesQuery(p, query, me, names));
+      if (query) out = out.filter(p => matchesQuery(p, query, me, extraBots, names));
       if (weightSel.length) out = out.filter(p => matchesWeightFilter(p, weightSel));
       if (stateSel.length) out = out.filter(p => stateSel.includes(actionState(p, me)));
       return out;
-   }, [pulls, isBot, boardHiddenExceptBots, scope.repos, query, me, names, weightSel, stateSel]);
+   }, [
+      pulls,
+      isBot,
+      boardHiddenExceptBots,
+      scope.repos,
+      query,
+      me,
+      names,
+      extraBots,
+      weightSel,
+      stateSel,
+   ]);
    // The CI lens's pool: `scoped` (which already respects hideBots, escape
    // hatch included) plus whatever bot the bypass pool above adds back —
    // deduped by key so a bot already visible in `scoped` (hideBots off, or

--- a/frontend-v2/src/app.tsx
+++ b/frontend-v2/src/app.tsx
@@ -428,16 +428,22 @@ export function App() {
          scope.authors.includes(login) || queryAuthors.some(q => login.toLowerCase().includes(q)),
       [scope.authors, queryAuthors]
    );
+   // "is:bot" is a blanket reveal (it doesn't name a specific bot the way
+   // author:<login> does), so it's a query-level flag rather than another
+   // per-login predicate like revealedAuthor.
+   const queryHasBotToken = useMemo(
+      () => query.toLowerCase().split(/\s+/).includes('is:bot'),
+      [query]
+   );
 
-   // The one is-this-pull-off-the-board predicate: hidden repos, hidden
-   // people, cryo, snoozes, and the drafts rule stay off unless a session
-   // act reveals them — an explicit reveal, a scope, a repo:/author: query
-   // term, or the master "show everything". Never hides your own pulls; bots
-   // hide only when you turn on Ignore bot PRs (they otherwise have their own
-   // fold), and a person can't hide themselves. Shared by the filter pipeline and the
-   // hidden-PR ledger's counts so the ledger's number can never disagree
-   // with what the board actually withholds.
-   const boardHidden = useCallback(
+   // Every off-by-default rule EXCEPT "Ignore bot PRs": hidden repos/people,
+   // parked (cryo) pulls, and the drafts-mine default. Split out of
+   // boardHidden below so botsBypassingHideBots (further down, feeding the CI
+   // lens and Ready-to-merge) can reuse it for a bot pool that skips ONLY the
+   // hideBots rule — those two surfaces need bot signal (fleet build health,
+   // a merge-ready bot PR) even when a reviewer has muted bots from Review's
+   // human-review surfaces.
+   const boardHiddenExceptBots = useCallback(
       (p: DerivedPull) => {
          if (showAll) return false;
          const hidden = isHiddenFor(
@@ -459,15 +465,7 @@ export function App() {
             p.data.user.login !== me &&
             !revealedAuthor(p.data.user.login) &&
             !reviewRequestedFrom(p, me);
-         // snoozes are NOT here: a snooze only quiets the Review lens (its
-         // "not today" gesture), so the Review view applies it itself and
-         // every other lens still shows the pull
-         // "Ignore bot PRs": a saved preference that keeps machine authors off
-         // the board entirely (they otherwise live in their own low-priority
-         // fold). "Show everything" still reveals them via the showAll early
-         // return above.
-         const botHidden = settings.hideBots && isBot(p);
-         return hidden || cryoHidden || draftHidden || botHidden;
+         return hidden || cryoHidden || draftHidden;
       },
       [
          showAll,
@@ -479,9 +477,42 @@ export function App() {
          settings.repoPrefs,
          settings.showCryo,
          settings.hiddenPeople,
-         settings.hideBots,
          draftsMode,
       ]
+   );
+
+   // The one is-this-pull-off-the-board predicate: hidden repos, hidden
+   // people, cryo, snoozes, and the drafts rule stay off unless a session
+   // act reveals them — an explicit reveal, a scope, a repo:/author: query
+   // term, or the master "show everything". Never hides your own pulls; bots
+   // hide only when you turn on Ignore bot PRs (they otherwise have their own
+   // fold), and a person can't hide themselves. Shared by the filter pipeline and the
+   // hidden-PR ledger's counts so the ledger's number can never disagree
+   // with what the board actually withholds.
+   const boardHidden = useCallback(
+      (p: DerivedPull) => {
+         if (showAll) return false;
+         // snoozes are NOT here: a snooze only quiets the Review lens (its
+         // "not today" gesture), so the Review view applies it itself and
+         // every other lens still shows the pull
+         // "Ignore bot PRs": a saved preference that keeps machine authors off
+         // Review's human-review surfaces (they otherwise live in their own
+         // low-priority fold and the queue tail). A bot named by the active
+         // saved/pinned filter (revealedAuthor, via scope.authors carrying its
+         // login) or a typed author:<bot> / is:bot query term still shows —
+         // the same reveal story every other hidden rule gets. "Show
+         // everything" still reveals them via the showAll early return above.
+         // The CI lens and Ready-to-merge bypass this rule entirely, reveal or
+         // not (see botsBypassingHideBots below): fleet build health and a
+         // merge-ready bot PR matter regardless of this setting.
+         const botHidden =
+            settings.hideBots &&
+            isBot(p) &&
+            !revealedAuthor(p.data.user.login) &&
+            !queryHasBotToken;
+         return boardHiddenExceptBots(p) || botHidden;
+      },
+      [showAll, boardHiddenExceptBots, settings.hideBots, isBot, revealedAuthor, queryHasBotToken]
    );
 
    // Nudges/notifications honor the STANDING hidden-repo/hidden-person
@@ -550,6 +581,32 @@ export function App() {
    // (each keystroke, settings toggle, and heartbeat re-runs App)
    const humans = useMemo(() => scoped.filter(p => !isBot(p)), [scoped, isBot]);
    const bots = useMemo(() => scoped.filter(isBot), [scoped, isBot]);
+
+   // Bots that pass every hidden rule except "Ignore bot PRs": hidden
+   // repos/people, cryo, and the drafts rule still apply, and the active
+   // repo scope / weight / state / query filters narrow it the same way
+   // they narrow `scoped` (scope.authors/notAuthors don't need repeating
+   // here — bots already bypass both in preWeightScoped above). Only the
+   // hideBots-specific exclusion is skipped. Feeds the CI lens and
+   // Ready-to-merge (below), the two surfaces that need bot signal
+   // regardless of hideBots.
+   const botsBypassingHideBots = useMemo(() => {
+      let out = pulls.filter(p => isBot(p) && !boardHiddenExceptBots(p));
+      if (scope.repos.length) out = out.filter(p => scope.repos.includes(p.data.repo));
+      if (query) out = out.filter(p => matchesQuery(p, query, me, names));
+      if (weightSel.length) out = out.filter(p => matchesWeightFilter(p, weightSel));
+      if (stateSel.length) out = out.filter(p => stateSel.includes(actionState(p, me)));
+      return out;
+   }, [pulls, isBot, boardHiddenExceptBots, scope.repos, query, me, names, weightSel, stateSel]);
+   // The CI lens's pool: `scoped` (which already respects hideBots, escape
+   // hatch included) plus whatever bot the bypass pool above adds back —
+   // deduped by key so a bot already visible in `scoped` (hideBots off, or
+   // individually revealed) is never doubled.
+   const ciPulls = useMemo(() => {
+      const scopedKeys = new Set(scoped.map(p => pullKey(p.data)));
+      const extraBots = botsBypassingHideBots.filter(p => !scopedKeys.has(pullKey(p.data)));
+      return extraBots.length ? [...scoped, ...extraBots] : scoped;
+   }, [scoped, botsBypassingHideBots]);
    // every known repo with its open-PR count — feeds the Filters popover and
    // the Settings repo manager. Includes pref'd repos at 0.
    const repoCounts = useMemo(() => {
@@ -1024,9 +1081,9 @@ export function App() {
                   sessionActive={sessionActive}
                   inputProps={{
                      'aria-label':
-                        'Filter PRs: text, #number, label:x, status:x, older:5, repo:x, author:x, weight:xs, has:action, is:draft, is:mine, is:restamp, is:blocked',
+                        'Filter PRs: text, #number, label:x, status:x, older:5, repo:x, author:x, weight:xs, has:action, is:draft, is:mine, is:restamp, is:blocked, is:bot',
                      placeholder: 'Filter (press /)',
-                     title: 'text, #number, label:x, status:x, older:5, repo:x, author:x, weight:xs, has:action, is:draft, is:mine, is:restamp, is:blocked',
+                     title: 'text, #number, label:x, status:x, older:5, repo:x, author:x, weight:xs, has:action, is:draft, is:mine, is:restamp, is:blocked, is:bot',
                      className: `w-[210px] max-w-full grow pr-2.5 pl-8 sm:grow-0 ${textInputClass}`,
                   }}
                />
@@ -1069,6 +1126,7 @@ export function App() {
                <Review
                   pulls={humans}
                   bots={bots}
+                  botsForReady={botsBypassingHideBots}
                   closed={scopedClosed}
                   opts={{ ...rowOpts, showSnooze: true }}
                />
@@ -1087,7 +1145,7 @@ export function App() {
                />
             )}
             {initialized && lens === 'classic' && <Classic pulls={scoped} opts={rowOpts} />}
-            {initialized && lens === 'ci' && <Ci pulls={scoped} opts={rowOpts} />}
+            {initialized && lens === 'ci' && <Ci pulls={ciPulls} opts={rowOpts} />}
             {initialized && lens === 'stats' && (
                <Stats pulls={humans} closed={closed} me={me} onPerson={onPerson} />
             )}

--- a/frontend-v2/src/components/NotificationPanel.tsx
+++ b/frontend-v2/src/components/NotificationPanel.tsx
@@ -398,7 +398,7 @@ export function NotificationPanel({
                                        rel="noopener noreferrer"
                                        className="mt-0.5 block font-medium text-brand hover:underline"
                                     >
-                                       #{r.toast.pull.number}
+                                       {shortRepo(r.toast.pull.repo)}#{r.toast.pull.number}
                                        {r.toast.pull.title ? ` ${r.toast.pull.title}` : ''}
                                     </a>
                                  )

--- a/frontend-v2/src/components/NotificationPanel.tsx
+++ b/frontend-v2/src/components/NotificationPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ArrowLeft, Bell, Settings as SettingsIcon, X } from 'lucide-react';
-import { ago, githubUrl } from '../../../shared/format';
+import { ago, githubUrl, pullKey, shortRepo } from '../../../shared/format';
 import { type CheerGroup, CONFIGURABLE_TOASTS } from '../model/cheers';
 import {
    type Settings as SettingsShape,
@@ -15,6 +15,7 @@ import {
    testNotification,
    unlockSound,
 } from '../notifications';
+import { TOAST_PULLS_SHOWN } from '../model/toast';
 import type { ToastRecord } from '../toasts';
 import { HeaderIconButton, QuietButton, Segmented, Switch } from './bits';
 import { Icon } from './Icon';
@@ -361,23 +362,46 @@ export function NotificationPanel({
                            </span>
                            <span className="min-w-0 flex-1">
                               <span className="flex items-baseline justify-between gap-2">
-                                 <span className="truncate font-semibold text-ink">
+                                 <span className="font-semibold text-ink">
+                                    {r.toast.count != null && `${r.toast.count} `}
                                     {r.toast.title}
                                  </span>
                                  <span className="flex-none text-[10px] text-ink-3 tabular-nums">
                                     {ago(r.at / 1000)}
                                  </span>
                               </span>
-                              {r.toast.pull && (
-                                 <a
-                                    href={githubUrl(r.toast.pull.repo, r.toast.pull.number)}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="mt-0.5 block truncate font-medium text-brand hover:underline"
-                                 >
-                                    #{r.toast.pull.number}
-                                    {r.toast.pull.title ? ` ${r.toast.pull.title}` : ''}
-                                 </a>
+                              {r.toast.pulls && r.toast.pulls.length > 0 ? (
+                                 <span className="mt-0.5 flex flex-col gap-0.5">
+                                    {r.toast.pulls.slice(0, TOAST_PULLS_SHOWN).map(p => (
+                                       <a
+                                          key={pullKey(p)}
+                                          href={githubUrl(p.repo, p.number)}
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                          className="block font-medium text-brand hover:underline"
+                                       >
+                                          {shortRepo(p.repo)}#{p.number}
+                                          {p.title ? ` ${p.title}` : ''}
+                                       </a>
+                                    ))}
+                                    {r.toast.pulls.length > TOAST_PULLS_SHOWN && (
+                                       <span className="block text-ink-3">
+                                          +{r.toast.pulls.length - TOAST_PULLS_SHOWN} more
+                                       </span>
+                                    )}
+                                 </span>
+                              ) : (
+                                 r.toast.pull && (
+                                    <a
+                                       href={githubUrl(r.toast.pull.repo, r.toast.pull.number)}
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       className="mt-0.5 block font-medium text-brand hover:underline"
+                                    >
+                                       #{r.toast.pull.number}
+                                       {r.toast.pull.title ? ` ${r.toast.pull.title}` : ''}
+                                    </a>
+                                 )
                               )}
                               {r.toast.body && (
                                  <span className="mt-0.5 block text-ink-2">{r.toast.body}</span>

--- a/frontend-v2/src/components/Popover.tsx
+++ b/frontend-v2/src/components/Popover.tsx
@@ -1,4 +1,10 @@
-import { useLayoutEffect, useState, type ReactNode, type Ref } from 'react';
+import {
+   type PointerEvent as ReactPointerEvent,
+   useLayoutEffect,
+   useState,
+   type ReactNode,
+   type Ref,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { usePopover } from './usePopover';
 
@@ -8,9 +14,10 @@ export interface PopoverTriggerProps {
    'aria-expanded': boolean;
    onClick: () => void;
    /** present only with `hoverTriggerOnly`: the hover handlers move off the
-    * root and onto the trigger element itself */
-   onMouseEnter?: () => void;
-   onMouseLeave?: () => void;
+    * root and onto the trigger element itself. Pointer events, not mouse, so
+    * the hover-arm can be gated to a real mouse and skip touch taps. */
+   onPointerEnter?: (e: ReactPointerEvent) => void;
+   onPointerLeave?: (e: ReactPointerEvent) => void;
 }
 
 /**

--- a/frontend-v2/src/components/Row.tsx
+++ b/frontend-v2/src/components/Row.tsx
@@ -280,7 +280,7 @@ function useRowActions(pull: DerivedPull) {
          setCopied(true);
          setTimeout(() => setCopied(false), 1200);
       },
-      snooze: () => snoozePull(pullKey(pull.data)),
+      snooze: () => snoozePull(pull.data),
       unsnooze: () => unsnoozePull(pullKey(pull.data)),
       refresh: () => {
          refreshPull(pull.data.repo, pull.data.number);

--- a/frontend-v2/src/components/bits.tsx
+++ b/frontend-v2/src/components/bits.tsx
@@ -401,20 +401,50 @@ export function Switch({
    );
 }
 
-export function EmptyState({ title, sub }: { title: string; sub: string }) {
+export function EmptyState({
+   title,
+   sub,
+   variant = 'ok',
+}: {
+   title: string;
+   sub: string;
+   /** 'ok' is the green check: a genuine all-clear, nothing left to do (a good
+    * state). 'search' is the muted magnifying glass, for a null result from
+    * narrowing the board (a search or filter matched nothing) — where the check
+    * would wrongly read as success. Both draw the same stroke-in. */
+   variant?: 'ok' | 'search';
+}) {
    return (
       <div className="flex flex-col items-center gap-2.5 px-6 py-10 text-center text-[13px] text-ink-3">
-         <svg viewBox="0 0 36 36" fill="none" aria-hidden className="h-9 w-9">
-            <circle cx="18" cy="18" r="16" stroke="var(--ok)" strokeWidth="2" />
-            <path
-               className="draw-check"
-               d="M11 18.5l5 5 9-11"
-               stroke="var(--ok)"
-               strokeWidth="2.5"
-               strokeLinecap="round"
-               strokeLinejoin="round"
-            />
-         </svg>
+         {variant === 'search' ? (
+            // pathLength normalizes the lens+handle to the check's 26, so the
+            // one draw-check keyframe animates either glyph. currentColor keeps
+            // it in the muted ink of the surrounding copy: informational, not an
+            // alarm and not a success.
+            <svg viewBox="0 0 36 36" fill="none" aria-hidden className="h-9 w-9">
+               <path
+                  className="draw-check"
+                  pathLength={26}
+                  d="M8 15a7 7 0 1 0 14 0a7 7 0 1 0-14 0M20 20l6.5 6.5"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+               />
+            </svg>
+         ) : (
+            <svg viewBox="0 0 36 36" fill="none" aria-hidden className="h-9 w-9">
+               <circle cx="18" cy="18" r="16" stroke="var(--ok)" strokeWidth="2" />
+               <path
+                  className="draw-check"
+                  d="M11 18.5l5 5 9-11"
+                  stroke="var(--ok)"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+               />
+            </svg>
+         )}
          <span className="text-sm font-semibold text-ink-2">{title}</span>
          <span>{sub}</span>
       </div>

--- a/frontend-v2/src/components/bits.tsx
+++ b/frontend-v2/src/components/bits.tsx
@@ -417,20 +417,30 @@ export function EmptyState({
    return (
       <div className="flex flex-col items-center gap-2.5 px-6 py-10 text-center text-[13px] text-ink-3">
          {variant === 'search' ? (
-            // pathLength normalizes the lens+handle to the check's 26, so the
-            // one draw-check keyframe animates either glyph. currentColor keeps
-            // it in the muted ink of the surrounding copy: informational, not an
-            // alarm and not a success.
-            <svg viewBox="0 0 36 36" fill="none" aria-hidden className="h-9 w-9">
+            // search-alert (lucide): the magnifying glass draws in like the
+            // check (pathLength normalizes the lens+handle to 26 so the one
+            // draw-check keyframe animates it), then the exclamation pops in
+            // last to pull the eye to "nothing matched." currentColor keeps it
+            // in the muted ink of the copy: a heads-up, not a red alarm.
+            <svg
+               viewBox="0 0 24 24"
+               fill="none"
+               aria-hidden
+               className="h-9 w-9"
+               stroke="currentColor"
+               strokeWidth={2}
+               strokeLinecap="round"
+               strokeLinejoin="round"
+            >
                <path
                   className="draw-check"
                   pathLength={26}
-                  d="M8 15a7 7 0 1 0 14 0a7 7 0 1 0-14 0M20 20l6.5 6.5"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
+                  d="M3 11a8 8 0 1 0 16 0a8 8 0 1 0-16 0M16.65 16.65 21 21"
                />
+               <g className="alert-pop">
+                  <path d="M11 7v4" />
+                  <path d="M11 15h.01" />
+               </g>
             </svg>
          ) : (
             <svg viewBox="0 0 36 36" fill="none" aria-hidden className="h-9 w-9">

--- a/frontend-v2/src/components/usePopover.ts
+++ b/frontend-v2/src/components/usePopover.ts
@@ -52,16 +52,18 @@ export function usePopover<Panel extends HTMLElement, Trigger extends HTMLElemen
       setOpen(!open);
    };
 
-   // Only a real mouse previews on hover. Touch has no hover: a tap
+   // Only touch is excluded from hover. Touch has no hover: a tap
    // synthesizes pointerenter, which used to arm the open timer and fire the
    // preview ~250ms LATER, after the tap's real action (a link navigation, a
    // filter) had already run — an uninvited popover on top of the page you
-   // were just sent to. Gating on pointerType keeps desktop hover intact and
-   // handles hybrid mouse+touch devices per interaction, unlike a device-level
-   // (hover: hover) check. Button doors still open on tap via toggle() (a
-   // click), so touch keeps every tap-to-open popover.
+   // were just sent to. Gating on pointerType === 'touch' (rather than
+   // requiring 'mouse') keeps desktop hover intact, handles hybrid
+   // mouse+touch devices per interaction unlike a device-level (hover: hover)
+   // check, and lets a stylus ('pen') and any other non-touch pointer keep
+   // hover too. Button doors still open on tap via toggle() (a click), so
+   // touch keeps every tap-to-open popover.
    const onPointerEnter = (e: ReactPointerEvent) => {
-      if (!opts?.hover || e.pointerType !== 'mouse') return;
+      if (!opts?.hover || e.pointerType === 'touch') return;
       clearClose();
       // a short intent delay (a user setting): brushing the cursor across a row
       // of triggers shouldn't flash their panels open one after another. Read
@@ -73,7 +75,7 @@ export function usePopover<Panel extends HTMLElement, Trigger extends HTMLElemen
       else openTimer.current = setTimeout(() => setOpen(true), delay);
    };
    const onPointerLeave = (e: ReactPointerEvent) => {
-      if (!opts?.hover || e.pointerType !== 'mouse') return;
+      if (!opts?.hover || e.pointerType === 'touch') return;
       clearOpen();
       if (pinned.current) return;
       clearClose();

--- a/frontend-v2/src/components/usePopover.ts
+++ b/frontend-v2/src/components/usePopover.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { type PointerEvent as ReactPointerEvent, useEffect, useRef, useState } from 'react';
 import { getSettings } from '../settings';
 
 /**
@@ -52,8 +52,16 @@ export function usePopover<Panel extends HTMLElement, Trigger extends HTMLElemen
       setOpen(!open);
    };
 
-   const onMouseEnter = () => {
-      if (!opts?.hover) return;
+   // Only a real mouse previews on hover. Touch has no hover: a tap
+   // synthesizes pointerenter, which used to arm the open timer and fire the
+   // preview ~250ms LATER, after the tap's real action (a link navigation, a
+   // filter) had already run — an uninvited popover on top of the page you
+   // were just sent to. Gating on pointerType keeps desktop hover intact and
+   // handles hybrid mouse+touch devices per interaction, unlike a device-level
+   // (hover: hover) check. Button doors still open on tap via toggle() (a
+   // click), so touch keeps every tap-to-open popover.
+   const onPointerEnter = (e: ReactPointerEvent) => {
+      if (!opts?.hover || e.pointerType !== 'mouse') return;
       clearClose();
       // a short intent delay (a user setting): brushing the cursor across a row
       // of triggers shouldn't flash their panels open one after another. Read
@@ -64,8 +72,8 @@ export function usePopover<Panel extends HTMLElement, Trigger extends HTMLElemen
       if (delay <= 0) setOpen(true);
       else openTimer.current = setTimeout(() => setOpen(true), delay);
    };
-   const onMouseLeave = () => {
-      if (!opts?.hover) return;
+   const onPointerLeave = (e: ReactPointerEvent) => {
+      if (!opts?.hover || e.pointerType !== 'mouse') return;
       clearOpen();
       if (pinned.current) return;
       clearClose();
@@ -117,6 +125,6 @@ export function usePopover<Panel extends HTMLElement, Trigger extends HTMLElemen
       []
    );
 
-   const hoverProps = opts?.hover ? { onMouseEnter, onMouseLeave } : {};
+   const hoverProps = opts?.hover ? { onPointerEnter, onPointerLeave } : {};
    return { open, toggle, rootRef, panelRef, triggerRef, hoverProps };
 }

--- a/frontend-v2/src/model/actions.test.ts
+++ b/frontend-v2/src/model/actions.test.ts
@@ -397,6 +397,31 @@ describe('rowNote — the author matrix', () => {
          note({ status: 'needs_cr', changesRequestedBy: ['carol'], headPushedAt: 200 }, me)
       ).toEqual({ action: 'Address feedback', context: 'changes requested by carol' });
    });
+
+   it('a bot CHANGES_REQUESTED date never skews whether the author answered a human', () => {
+      // carol (human) requested changes at t=100; the author pushed at
+      // t=200, answering her. claude[bot] also left a later
+      // CHANGES_REQUESTED-flavored review at t=900 -- its date must not make
+      // carol's request look unanswered, or reset "Address feedback" over a
+      // human reviewer who's already been pushed past.
+      expect(
+         note(
+            {
+               status: 'needs_cr',
+               changesRequestedBy: ['carol'],
+               unstampedReviewers: [
+                  { login: 'carol', state: 'CHANGES_REQUESTED', date: 100 },
+                  { login: 'claude[bot]', state: 'CHANGES_REQUESTED', date: 900 },
+               ],
+               headPushedAt: 200,
+            },
+            me
+         )
+      ).toEqual({
+         action: null,
+         context: `waiting on carol to re-review · last commit ${ago(200)} ago`,
+      });
+   });
 });
 
 describe('parked (Cryogenic Storage) — asks nothing of anyone', () => {

--- a/frontend-v2/src/model/actions.ts
+++ b/frontend-v2/src/model/actions.ts
@@ -211,7 +211,7 @@ function authorNote(p: DerivedPull, me: string): RowNote {
  * send them). */
 function lastChangesRequestedAt(p: DerivedPull): number | null {
    const dates = (p.data.status.unstamped_reviewers ?? [])
-      .filter(r => r.state === 'CHANGES_REQUESTED')
+      .filter(r => r.state === 'CHANGES_REQUESTED' && !isSuffixBot(r.login))
       .map(r => r.date);
    return dates.length ? Math.max(...dates) : null;
 }

--- a/frontend-v2/src/model/notificationRelevance.test.ts
+++ b/frontend-v2/src/model/notificationRelevance.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { SHIPPED_TOAST_KIND } from './cheers';
+import { notificationStale } from './notificationRelevance';
+import type { Toast } from './toast';
+
+/** A toast carrying only the fields the relevance check reads. */
+function toast(o: Partial<Toast>): Toast {
+   return { tone: 'info', icon: '🤝', title: 't', ...o };
+}
+
+const ref = (repo: string, number: number) => ({ repo, number });
+
+describe('notificationStale', () => {
+   const open = new Set(['fixbot#3116', 'org/repo#7']);
+
+   it('drops a single-pull nudge once its PR leaves the open board', () => {
+      // Kyle's report: "return the favor on fixbot#3116" after #3116 merged
+      const merged = toast({ kind: 'return-the-favor', pull: ref('fixbot', 3116) });
+      expect(notificationStale(merged, new Set(['org/repo#7']))).toBe(true);
+      // while the PR is still open, the nudge stays
+      expect(notificationStale(merged, open)).toBe(false);
+   });
+
+   it('keeps a toast that points at no PR (board-wide rewards)', () => {
+      const inboxZero = toast({ kind: 'inbox-zero', pull: undefined });
+      expect(notificationStale(inboxZero, new Set())).toBe(false);
+   });
+
+   it('never stales the retrospective shipped recap, even though its PRs are merged', () => {
+      const shipped = toast({
+         kind: SHIPPED_TOAST_KIND,
+         pulls: [ref('org/repo', 900), ref('org/repo', 901)],
+      });
+      expect(notificationStale(shipped, new Set())).toBe(false);
+   });
+
+   it('stales a batched toast only once every referenced pull is gone', () => {
+      const batch = toast({ pulls: [ref('org/repo', 7), ref('fixbot', 3116)] });
+      // one of the two still open -> still relevant
+      expect(notificationStale(batch, new Set(['org/repo#7']))).toBe(false);
+      // both gone -> stale
+      expect(notificationStale(batch, new Set())).toBe(true);
+   });
+
+   it('applies to every PR-linked kind, not just return-the-favor', () => {
+      for (const kind of ['your-turn', 'review-requested', 'pr-ci-red', 're-stamp-owed']) {
+         const t = toast({ kind, pull: ref('gone', 1) });
+         expect(notificationStale(t, open)).toBe(true);
+      }
+   });
+});

--- a/frontend-v2/src/model/notificationRelevance.ts
+++ b/frontend-v2/src/model/notificationRelevance.ts
@@ -1,0 +1,41 @@
+import { pullKey } from '../../../shared/format';
+import { SHIPPED_TOAST_KIND } from './cheers';
+import type { Toast } from './toast';
+
+/** Toast kinds that are ABOUT already-merged PRs, so a referenced pull missing
+ * from the open board is the whole point, not staleness. The shipped catch-up
+ * is the only one today; a new retrospective toast joins here. */
+const RETROSPECTIVE_KINDS: ReadonlySet<string> = new Set([SHIPPED_TOAST_KIND]);
+
+/** The pull keys a toast points you at: its single `pull`, its `pulls` batch,
+ * or neither (a board-wide reward like inbox-zero). */
+function toastPullKeys(toast: Toast): string[] {
+   const refs = toast.pulls?.length ? toast.pulls : toast.pull ? [toast.pull] : [];
+   return refs.map(pullKey);
+}
+
+/**
+ * Whether a fired notification has gone stale: the PR it points you at has left
+ * the open board (merged or closed), so whatever it asked you to do can't be
+ * done anymore. The notification panel drops these, so a nudge like "return the
+ * favor on fixbot#3116" removes itself the moment #3116 merges instead of
+ * lingering as a dead link (prod report, Kyle 2026-07-27).
+ *
+ * Deliberately general -- every PR-linked kind, not just return-the-favor -- so
+ * one rule governs the whole panel. Two shapes are never stale: a toast with no
+ * PR (inbox-zero, board-cleared, a milestone count), since there's nothing to
+ * resolve, and a retrospective recap (shipped), which lists merged PRs on
+ * purpose. A toast pointing at several pulls is stale only once every one of
+ * them is gone.
+ *
+ * `openKeys` is the set of pull keys currently on the OPEN board; a referenced
+ * key that's absent has merged or closed. Feed it the FULL board rather than
+ * the hidden-filtered subset, so a still-open PR you've merely hidden isn't
+ * mistaken for done.
+ */
+export function notificationStale(toast: Toast, openKeys: ReadonlySet<string>): boolean {
+   if (toast.kind && RETROSPECTIVE_KINDS.has(toast.kind)) return false;
+   const keys = toastPullKeys(toast);
+   if (keys.length === 0) return false;
+   return keys.every(key => !openKeys.has(key));
+}

--- a/frontend-v2/src/model/query.test.ts
+++ b/frontend-v2/src/model/query.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { DerivedPull, Weight } from '../../../shared/model/status';
-import { matchesQuery } from './query';
+import type { PullData } from '../../../shared/types';
+import { matchesClosedQuery, matchesQuery } from './query';
 
 function fake(
    over: Partial<{
@@ -162,5 +163,69 @@ describe('matchesQuery', () => {
       expect(matchesQuery(match, 'weight:xs is:blocked', 'viewer')).toBe(true);
       expect(matchesQuery(wrongWeight, 'weight:xs is:blocked', 'viewer')).toBe(false);
       expect(matchesQuery(wrongStatus, 'weight:xs is:blocked', 'viewer')).toBe(false);
+   });
+});
+
+function fakeClosed(
+   over: Partial<{
+      title: string;
+      repo: string;
+      author: string;
+      number: number;
+      labels: string[];
+   }>
+): PullData {
+   return {
+      title: over.title ?? 'Rework the offer-sync batch loop',
+      repo: over.repo ?? 'acme/widgets',
+      number: over.number ?? 63258,
+      user: { login: over.author ?? 'alice' },
+      labels: (over.labels ?? []).map(title => ({ title })),
+   } as unknown as PullData;
+}
+
+describe('matchesClosedQuery', () => {
+   it('matches the identity fields a find actually uses', () => {
+      const p = fakeClosed({
+         title: 'Store offer sync',
+         author: 'alice',
+         number: 42,
+         labels: ['QAE'],
+      });
+      expect(matchesClosedQuery(p, 'offer', 'viewer')).toBe(true);
+      expect(matchesClosedQuery(p, '42', 'viewer')).toBe(true);
+      expect(matchesClosedQuery(p, '#42', 'viewer')).toBe(true);
+      expect(matchesClosedQuery(p, 'repo:widgets', 'viewer')).toBe(true);
+      expect(matchesClosedQuery(p, 'author:ali', 'viewer')).toBe(true);
+      expect(matchesClosedQuery(p, 'label:qae', 'viewer')).toBe(true);
+      expect(matchesClosedQuery(p, 'offer nope', 'viewer')).toBe(false);
+   });
+
+   it('is:bot and is:mine work on a closed pull', () => {
+      expect(matchesClosedQuery(fakeClosed({ author: 'renovate[bot]' }), 'is:bot', 'viewer')).toBe(
+         true
+      );
+      expect(
+         matchesClosedQuery(
+            fakeClosed({ author: 'ifixit-systems' }),
+            'is:bot',
+            'viewer',
+            new Set(['ifixit-systems'])
+         )
+      ).toBe(true);
+      expect(matchesClosedQuery(fakeClosed({ author: 'alice' }), 'is:mine', 'alice')).toBe(true);
+      expect(matchesClosedQuery(fakeClosed({ author: 'alice' }), 'is:mine', 'bob')).toBe(false);
+   });
+
+   it('a state-only token never matches a closed pull (it has no live state)', () => {
+      // status:/weight:/older:/has:/is:restamp describe an OPEN board state, so a
+      // query using one shouldn't drag closed pulls into the results by accident
+      const p = fakeClosed({ title: 'offer sync' });
+      expect(matchesClosedQuery(p, 'status:ready', 'viewer')).toBe(false);
+      expect(matchesClosedQuery(p, 'weight:xs', 'viewer')).toBe(false);
+      expect(matchesClosedQuery(p, 'has:action', 'viewer')).toBe(false);
+      expect(matchesClosedQuery(p, 'is:restamp', 'viewer')).toBe(false);
+      // but a bare term in the same pull still matches on its own
+      expect(matchesClosedQuery(p, 'offer', 'viewer')).toBe(true);
    });
 });

--- a/frontend-v2/src/model/query.test.ts
+++ b/frontend-v2/src/model/query.test.ts
@@ -136,6 +136,11 @@ describe('matchesQuery', () => {
       expect(matchesQuery(fake({ status: 'ready' }), 'is:blocked', 'viewer')).toBe(false);
    });
 
+   it('is:bot matches a [bot]-suffixed author only', () => {
+      expect(matchesQuery(fake({ author: 'dependabot[bot]' }), 'is:bot', 'viewer')).toBe(true);
+      expect(matchesQuery(fake({ author: 'alice' }), 'is:bot', 'viewer')).toBe(false);
+   });
+
    it('unknown has:/is: values match nothing', () => {
       expect(matchesQuery(fake({}), 'has:bogus', 'viewer')).toBe(false);
       expect(matchesQuery(fake({}), 'is:bogus', 'viewer')).toBe(false);

--- a/frontend-v2/src/model/query.test.ts
+++ b/frontend-v2/src/model/query.test.ts
@@ -136,9 +136,18 @@ describe('matchesQuery', () => {
       expect(matchesQuery(fake({ status: 'ready' }), 'is:blocked', 'viewer')).toBe(false);
    });
 
-   it('is:bot matches a [bot]-suffixed author only', () => {
+   it('is:bot matches a [bot]-suffixed author', () => {
       expect(matchesQuery(fake({ author: 'dependabot[bot]' }), 'is:bot', 'viewer')).toBe(true);
       expect(matchesQuery(fake({ author: 'alice' }), 'is:bot', 'viewer')).toBe(false);
+   });
+
+   it("is:bot also matches a config.json extra-bots login, given the caller's set", () => {
+      const extraBots = new Set(['ifixit-systems']);
+      expect(matchesQuery(fake({ author: 'ifixit-systems' }), 'is:bot', 'viewer', extraBots)).toBe(
+         true
+      );
+      // absent the set (the default), a non-suffixed login isn't recognized as a bot
+      expect(matchesQuery(fake({ author: 'ifixit-systems' }), 'is:bot', 'viewer')).toBe(false);
    });
 
    it('unknown has:/is: values match nothing', () => {

--- a/frontend-v2/src/model/query.ts
+++ b/frontend-v2/src/model/query.ts
@@ -1,6 +1,6 @@
 import { authorOwnsIt, parked, rowNote } from './actions';
 import type { DerivedPull } from '../../../shared/model/status';
-import { isSuffixBot } from '../../../shared/model/visibility';
+import { isBotLogin } from '../../../shared/model/visibility';
 
 /**
  * The filter box grammar. Bare terms AND-match as substrings across title,
@@ -16,29 +16,35 @@ import { isSuffixBot } from '../../../shared/model/visibility';
  *   has:action    the viewer (`me`) has an imperative move on this card
  *   is:restamp    `me` owes a re-CR or re-QA on a reviewable pull
  *   is:blocked    status is dev_block or deploy_block
- *   is:bot        the author is a bot (the `[bot]` suffix; config.json's
- *                 extra `bots` list isn't visible here, same as any other
- *                 model-layer bot check)
+ *   is:bot        the author is a bot: the `[bot]` suffix OR a login named in
+ *                 config.json's `bots` list (the caller's `extraBots` set) —
+ *                 a query-layer bot check must agree with what the board
+ *                 itself treats as a bot, or an active is:bot term narrows a
+ *                 pool (app.tsx's CI/Ready bot pool included) to fewer PRs
+ *                 than that pool actually holds
  *
  * `me` is the viewer's login, needed only for has:/is: — every other token
- * ignores it. `names` is the optional login → display-name map (model/
- * names.ts): when present, author: and bare terms match the human name too,
- * so "metz" finds djmetzle.
+ * ignores it. `extraBots` is config.json's non-suffix bot logins (empty set
+ * if the caller has none), needed only for is:bot. `names` is the optional
+ * login → display-name map (model/names.ts): when present, author: and bare
+ * terms match the human name too, so "metz" finds djmetzle.
  */
 export function matchesQuery(
    p: DerivedPull,
    query: string,
    me: string,
+   extraBots: ReadonlySet<string> = new Set(),
    names?: Readonly<Record<string, string | null>>
 ): boolean {
    const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
-   return terms.every(t => matchTerm(p, t, me, names));
+   return terms.every(t => matchTerm(p, t, me, extraBots, names));
 }
 
 function matchTerm(
    p: DerivedPull,
    term: string,
    me: string,
+   extraBots: ReadonlySet<string>,
    names?: Readonly<Record<string, string | null>>
 ): boolean {
    const d = p.data;
@@ -70,7 +76,7 @@ function matchTerm(
             if (val === 'blocked') return p.status === 'dev_block' || p.status === 'deploy_block';
             if (val === 'draft') return p.status === 'draft';
             if (val === 'mine') return d.user.login.toLowerCase() === me.toLowerCase();
-            if (val === 'bot') return isSuffixBot(d.user.login);
+            if (val === 'bot') return isBotLogin(d.user.login, extraBots);
             // unrecognized is: value: fall through to the plain substring
             // match below, same as any other unknown key
          }

--- a/frontend-v2/src/model/query.ts
+++ b/frontend-v2/src/model/query.ts
@@ -1,5 +1,6 @@
 import { authorOwnsIt, parked, rowNote } from './actions';
 import type { DerivedPull } from '../../../shared/model/status';
+import { isSuffixBot } from '../../../shared/model/visibility';
 
 /**
  * The filter box grammar. Bare terms AND-match as substrings across title,
@@ -15,6 +16,9 @@ import type { DerivedPull } from '../../../shared/model/status';
  *   has:action    the viewer (`me`) has an imperative move on this card
  *   is:restamp    `me` owes a re-CR or re-QA on a reviewable pull
  *   is:blocked    status is dev_block or deploy_block
+ *   is:bot        the author is a bot (the `[bot]` suffix; config.json's
+ *                 extra `bots` list isn't visible here, same as any other
+ *                 model-layer bot check)
  *
  * `me` is the viewer's login, needed only for has:/is: — every other token
  * ignores it. `names` is the optional login → display-name map (model/
@@ -66,6 +70,7 @@ function matchTerm(
             if (val === 'blocked') return p.status === 'dev_block' || p.status === 'deploy_block';
             if (val === 'draft') return p.status === 'draft';
             if (val === 'mine') return d.user.login.toLowerCase() === me.toLowerCase();
+            if (val === 'bot') return isSuffixBot(d.user.login);
             // unrecognized is: value: fall through to the plain substring
             // match below, same as any other unknown key
          }

--- a/frontend-v2/src/model/query.ts
+++ b/frontend-v2/src/model/query.ts
@@ -1,5 +1,6 @@
 import { authorOwnsIt, parked, rowNote } from './actions';
 import type { DerivedPull } from '../../../shared/model/status';
+import type { PullData } from '../../../shared/types';
 import { isBotLogin } from '../../../shared/model/visibility';
 
 /**
@@ -91,5 +92,69 @@ function matchTerm(
       d.user.login.toLowerCase().includes(term) ||
       (authorName !== '' && authorName.includes(term)) ||
       d.labels.some(l => l.title.toLowerCase().includes(term))
+   );
+}
+
+/**
+ * The same grammar over a CLOSED pull (raw PullData, no derived status). The
+ * search lens runs this so a merged or closed PR is findable by the identity
+ * terms people actually search on: bare text, #number, repo:, author:, label:,
+ * is:bot, is:mine. Tokens that describe a live board state (status:, weight:,
+ * older:, has:action, is:restamp/blocked/draft) can't hold on something already
+ * closed, so a query using one deliberately excludes closed results rather than
+ * matching them by accident. Bare terms and identity tokens match exactly as
+ * matchTerm does for open pulls, so "offer" finds the same fields either side of
+ * the open/closed line.
+ */
+export function matchesClosedQuery(
+   pd: PullData,
+   query: string,
+   me: string,
+   extraBots: ReadonlySet<string> = new Set(),
+   names?: Readonly<Record<string, string | null>>
+): boolean {
+   const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+   return terms.every(t => matchClosedTerm(pd, t, me, extraBots, names));
+}
+
+/** State-only token keys: they read a live derivation a closed pull no longer
+ * has, so a closed pull can never satisfy them. */
+const OPEN_ONLY_KEYS = new Set(['status', 'weight', 'older', 'has']);
+
+function matchClosedTerm(
+   pd: PullData,
+   term: string,
+   me: string,
+   extraBots: ReadonlySet<string>,
+   names?: Readonly<Record<string, string | null>>
+): boolean {
+   const authorName = names?.[pd.user.login]?.toLowerCase() ?? '';
+   const i = term.indexOf(':');
+   if (i > 0) {
+      const key = term.slice(0, i);
+      const val = term.slice(i + 1);
+      if (val) {
+         if (key === 'repo') return pd.repo.toLowerCase().includes(val);
+         if (key === 'author')
+            return pd.user.login.toLowerCase().includes(val) || authorName.includes(val);
+         if (key === 'label') return pd.labels.some(l => l.title.toLowerCase().includes(val));
+         if (key === 'is') {
+            if (val === 'bot') return isBotLogin(pd.user.login, extraBots);
+            if (val === 'mine') return pd.user.login.toLowerCase() === me.toLowerCase();
+            // is:restamp/blocked/draft describe an open pull's state
+            return false;
+         }
+         if (OPEN_ONLY_KEYS.has(key)) return false;
+         // unknown key: fall through to the substring match below
+      }
+   }
+   const bare = term.startsWith('#') ? term.slice(1) : term;
+   if (/^\d+$/.test(bare)) return String(pd.number).includes(bare);
+   return (
+      pd.title.toLowerCase().includes(term) ||
+      pd.repo.toLowerCase().includes(term) ||
+      pd.user.login.toLowerCase().includes(term) ||
+      (authorName !== '' && authorName.includes(term)) ||
+      pd.labels.some(l => l.title.toLowerCase().includes(term))
    );
 }

--- a/frontend-v2/src/model/repoBlocks.test.ts
+++ b/frontend-v2/src/model/repoBlocks.test.ts
@@ -27,13 +27,13 @@ describe('repoBlocks', () => {
       expect(shape(repoBlocks(queue, ['ops'])).blocks[0].nums).toEqual([9, 1, 5]);
    });
 
-   it('starved pulls pierce the partition and lead in their own order', () => {
+   it('surfaces starved pulls as a highlight while keeping them in their own repo block', () => {
       const queue = [pull('mono', 1), pull('ops', 2, true), pull('mono', 3, true), pull('ops', 4)];
       expect(shape(repoBlocks(queue, ['mono', 'ops']))).toEqual({
          starved: [2, 3],
          blocks: [
-            { repo: 'mono', nums: [1] },
-            { repo: 'ops', nums: [4] },
+            { repo: 'mono', nums: [1, 3] },
+            { repo: 'ops', nums: [2, 4] },
          ],
       });
    });

--- a/frontend-v2/src/model/repoBlocks.ts
+++ b/frontend-v2/src/model/repoBlocks.ts
@@ -10,9 +10,12 @@ import type { DerivedPull } from '../../../shared/model/status';
  * monopolize the screen).
  *
  * Two guarantees survive the partition:
- * - Starved pulls pierce it. They lead the lane regardless of repo, in their
- *   existing rank order — the fairness backstop must not sit below a repo
- *   the viewer ranked last, or "surface the other repos" becomes a lie.
+ * - Starved pulls are surfaced as a highlight (returned separately, still in
+ *   rank order) AND kept in their own repo block — a starved pull from a
+ *   low-priority repo is never hidden by a higher-priority repo's block,
+ *   unlike an earlier version that extracted starved pulls out of the
+ *   blocks entirely and could bury one behind a high-volume repo's "show
+ *   more" fold.
  * - Order WITHIN a block is exactly the incoming order (stable partition),
  *   so teammates still lead and the score still ranks — the priority only
  *   decides which repo's run comes first, never which pull is "best".
@@ -31,9 +34,8 @@ export function repoBlocks(
    priority: string[]
 ): { starved: DerivedPull[]; blocks: RepoBlock[] } {
    const starved = queue.filter(p => p.starved);
-   const rest = queue.filter(p => !p.starved);
    const byRepo = new Map<string, DerivedPull[]>();
-   for (const p of rest) {
+   for (const p of queue) {
       const list = byRepo.get(p.data.repo);
       if (list) list.push(p);
       else byRepo.set(p.data.repo, [p]);

--- a/frontend-v2/src/model/reviewLanes.test.ts
+++ b/frontend-v2/src/model/reviewLanes.test.ts
@@ -367,6 +367,16 @@ describe('buildReviewLanes — board summary', () => {
       expect(lanes.empty).toBe(false);
    });
 
+   it('is not empty when botsForReady holds a ready bot, even with pulls/bots/closed all empty', () => {
+      // the bug: "Ignore bot PRs" empties `bots`, and empty only checked
+      // pulls/bots/closed — a merge-ready bot reachable through botsForReady
+      // (and showing in lanes.ready) still read as "All clear"
+      const bot = dp({ author: 'dependabot[bot]', status: 'ready' });
+      const lanes = buildReviewLanes(input({ botsForReady: [bot] }));
+      expect(lanes.empty).toBe(false);
+      expect(lanes.ready).toContain(bot);
+   });
+
    it('boardIsQuiet is false once the queue has something in it', () => {
       const p = dp({ author: 'alice', status: 'needs_cr' });
       const lanes = buildReviewLanes(input({ pulls: [p] }));

--- a/frontend-v2/src/model/reviewLanes.test.ts
+++ b/frontend-v2/src/model/reviewLanes.test.ts
@@ -260,11 +260,11 @@ describe('buildReviewLanes — waiting on you vs waiting on others', () => {
 });
 
 describe('buildReviewLanes — region matches', () => {
-   it('surfaces a pull matching a configured code region and pulls it out of the queue', () => {
+   it('surfaces a pull matching a configured code region as a highlight, without removing it from the queue', () => {
       const p = dp({ author: 'alice', status: 'needs_cr', title: 'Rework the Shopify sync' });
       const lanes = buildReviewLanes(input({ pulls: [p], codeRegions: ['Shopify'] }));
       expect(lanes.regionMatches).toEqual([p]);
-      expect(lanes.queue).not.toContain(p);
+      expect(lanes.queue).toContain(p);
    });
 
    it('leaves regionMatches empty when no regions are configured', () => {
@@ -274,7 +274,7 @@ describe('buildReviewLanes — region matches', () => {
       expect(lanes.queue).toEqual([p]);
    });
 
-   it('pulls a QA-pool match out of needsQa into regionMatches too', () => {
+   it('surfaces a QA-pool match in regionMatches too, without removing it from needsQa', () => {
       const p = dp({
          author: 'alice',
          status: 'needs_qa',
@@ -282,7 +282,40 @@ describe('buildReviewLanes — region matches', () => {
       });
       const lanes = buildReviewLanes(input({ pulls: [p], codeRegions: ['Shopify'] }));
       expect(lanes.regionMatches).toEqual([p]);
-      expect(lanes.needsQa).not.toContain(p);
+      expect(lanes.needsQa).toContain(p);
+   });
+
+   it('excludes a pull you already CR-stamped from regionMatches, even via the QA pool', () => {
+      // qaPool itself doesn't care about crBy — a needs_qa pull with a live
+      // stamp from you would otherwise sail through the QA-pool leg and land
+      // in "your code regions" as if it were news to you. It still belongs
+      // in needsQa (that lane's own filters don't look at crBy at all).
+      const p = dp({
+         author: 'alice',
+         status: 'needs_qa',
+         crBy: ['me'],
+         title: 'Rework the Shopify sync',
+      });
+      const lanes = buildReviewLanes(input({ pulls: [p], codeRegions: ['Shopify'] }));
+      expect(lanes.regionMatches).not.toContain(p);
+      expect(lanes.needsQa).toContain(p);
+   });
+
+   it('keeps a needs_recr pull in regionMatches when only your own stamp went stale', () => {
+      // recrBy including you means YOUR re-stamp is owed (a "Re-stamp" verb
+      // in Waiting on you) and crBy no longer includes you, since a stale
+      // stamp drops out of the active crBy set. The new qaPool exclusion
+      // only checks crBy (a currently-live stamp), so this pull still
+      // matches through the QA-pool leg.
+      const p = dp({
+         author: 'alice',
+         status: 'needs_recr',
+         recrBy: ['me'],
+         crBy: [],
+         title: 'Rework the Shopify sync',
+      });
+      const lanes = buildReviewLanes(input({ pulls: [p], codeRegions: ['Shopify'] }));
+      expect(lanes.regionMatches).toContain(p);
    });
 });
 

--- a/frontend-v2/src/model/reviewLanes.test.ts
+++ b/frontend-v2/src/model/reviewLanes.test.ts
@@ -333,6 +333,21 @@ describe('buildReviewLanes — stamped and ready lanes', () => {
       expect(lanes.ready).toEqual([bot, human]);
    });
 
+   it('draws ready’s bot portion from botsForReady, not bots, when the two differ', () => {
+      // "Ignore bot PRs" empties `bots` (the queue-tail/fold pool) but
+      // botsForReady bypasses that setting — Ready-to-merge must still
+      // surface the bot PR even though it's absent from `bots`.
+      const bot = dp({ author: 'dependabot[bot]', status: 'ready' });
+      const lanes = buildReviewLanes(input({ pulls: [], bots: [], botsForReady: [bot] }));
+      expect(lanes.ready).toEqual([bot]);
+   });
+
+   it('falls back to bots for ready when botsForReady is omitted', () => {
+      const bot = dp({ author: 'dependabot[bot]', status: 'ready' });
+      const lanes = buildReviewLanes(input({ pulls: [], bots: [bot] }));
+      expect(lanes.ready).toEqual([bot]);
+   });
+
    it('keeps a stamped (CR-incomplete, your stamp live) pull out of the queue and in yoursWaiting', () => {
       const p = dp({ author: 'alice', status: 'needs_cr', crBy: ['me'], crReq: 2 });
       const lanes = buildReviewLanes(input({ pulls: [p] }));

--- a/frontend-v2/src/model/reviewLanes.ts
+++ b/frontend-v2/src/model/reviewLanes.ts
@@ -92,8 +92,9 @@ export interface ReviewLanes {
    /** the review queue's contiguous per-repo blocks (only meaningful with
     * repoPriority set) */
    queueBlocks: RepoBlock[];
-   /** CR- or QA-pool pulls matching a configured code region, deduped and
-    * pulled out of every lane below */
+   /** CR- or QA-pool pulls matching a configured code region, deduped — a
+    * highlight copy, not an extraction: matches also stay in the queue/QA
+    * lanes below */
    regionMatches: DerivedPull[];
    needsQa: DerivedPull[];
    needsQaOther: DerivedPull[];
@@ -259,20 +260,23 @@ export function buildReviewLanes(input: ReviewLanesInput): ReviewLanes {
       );
 
    // In your code regions: reviewable pulls (CR or QA pool) matching a region
-   // you set in Settings, deduped across the two pools and genuinely pulled
-   // out of the queue/QA lanes below (including their "other repos" folds)
-   // into their own section — the most explicit "this is my area" signal
-   // earns its own spot instead of a float within the queue.
+   // you set in Settings, deduped across the two pools, surfaced as a
+   // highlight above the queue/QA lanes below — a copy of a slice, not an
+   // extraction (the same non-exclusive relationship "Recently updated" and
+   // a claimed PR already have with their lanes): a region match still shows
+   // up in its normal queue/QA spot too. The QA-pool leg excludes a pull you
+   // already hold a live CR stamp on — you've already reviewed it, so it
+   // isn't region news to you, even though qaPool itself doesn't otherwise
+   // care about CR state.
    const regionSeen = new Set<string>();
    const regionMatches = crSort(
-      [...crPool, ...qaPool].filter(p => {
+      [...crPool, ...qaPool.filter(p => !p.crBy.includes(me))].filter(p => {
          const k = pullKey(p.data);
          if (regionSeen.has(k) || !matchesRegion(p, codeRegions)) return false;
          regionSeen.add(k);
          return true;
       })
    );
-   const regionKeys = new Set(regionMatches.map(p => pullKey(p.data)));
 
    // ONE review queue: your primary repos' reviewables, every starved pull
    // regardless of repo (the fairness backstop rides in the ranking now, not
@@ -280,26 +284,24 @@ export function buildReviewLanes(input: ReviewLanesInput): ReviewLanes {
    // them to the top numerically instead of positionally), and the day's bot
    // bumps sinking to the tail. The top of this lane IS the board's best
    // next pickup; the retired "Deal me one" button dealt this exact order,
-   // which is why the button became redundant and was removed. Non-starved work outside your primary repos still
-   // folds into "other repos" below, reachable but not in the way. Region
-   // matches are excluded here too (same Set-filter pattern as botKeys) — they
-   // live in their own lane above, not doubled up in the queue.
+   // which is why the button became redundant and was removed. Non-starved
+   // work outside your primary repos still folds into "other repos" below,
+   // reachable but not in the way. Region matches stay in this queue too:
+   // "In your code regions" above is a highlight, a copy of a slice, not an
+   // extraction — the same non-exclusive relationship "Recently updated" and
+   // a claimed PR already have with their lanes.
    const queue = teamFirst(
       dealRank(
          [
-            ...nonStarved.filter(
-               p => isPrimaryRepo(p.data.repo) && !regionKeys.has(pullKey(p.data))
-            ),
-            ...crPool.filter(p => p.starved && !regionKeys.has(pullKey(p.data))),
+            ...nonStarved.filter(p => isPrimaryRepo(p.data.repo)),
+            ...crPool.filter(p => p.starved),
             ...botReviewable,
          ],
          { me, pulls, deprioritize: isDemoted, warnDays: ageWarnDays }
       ),
       team
    );
-   const queueOther = crSort(
-      nonStarved.filter(p => !isPrimaryRepo(p.data.repo) && !regionKeys.has(pullKey(p.data)))
-   );
+   const queueOther = crSort(nonStarved.filter(p => !isPrimaryRepo(p.data.repo)));
 
    // Ready to merge is finishable work for anyone: fully signed off, green,
    // one button-press from done. It earns a real lane in Pick up next rather
@@ -310,13 +312,8 @@ export function buildReviewLanes(input: ReviewLanesInput): ReviewLanes {
       ...bots.filter(p => p.status === 'ready'),
    ].sort((a, b) => b.ageDays - a.ageDays);
 
-   const needsQa = teamFirst(
-      qaSort(qaPool.filter(p => isPrimaryRepo(p.data.repo) && !regionKeys.has(pullKey(p.data)))),
-      team
-   );
-   const needsQaOther = qaSort(
-      qaPool.filter(p => !isPrimaryRepo(p.data.repo) && !regionKeys.has(pullKey(p.data)))
-   );
+   const needsQa = teamFirst(qaSort(qaPool.filter(p => isPrimaryRepo(p.data.repo))), team);
+   const needsQaOther = qaSort(qaPool.filter(p => !isPrimaryRepo(p.data.repo)));
 
    // your live CR stamp is in, the PR just isn't fully signed off yet (another
    // reviewer owes a stamp, or a re-CR). Covers needs_recr too, so a PR you

--- a/frontend-v2/src/model/reviewLanes.ts
+++ b/frontend-v2/src/model/reviewLanes.ts
@@ -32,8 +32,18 @@ export interface ReviewLanesInput {
     * against the store's `snoozed` map) has already run, so a snoozed pull
     * never reaches the lane math below. */
    pulls: DerivedPull[];
-   /** same pool, bot pulls (dependency bumps etc.) — snoozed already excluded */
+   /** same pool, bot pulls (dependency bumps etc.) — snoozed already excluded.
+    * This pool empties out when "Ignore bot PRs" hides bots from Review's
+    * human-review surfaces (the queue tail, the bot fold), unless a filter
+    * reveals them. */
    bots: DerivedPull[];
+   /** the bot pool Ready-to-merge draws from instead of `bots` — bypasses
+    * "Ignore bot PRs" (a green, signed-off bot PR is one merge press from
+    * done regardless of that setting), while still respecting every other
+    * hide (hidden repo/person, cryo, drafts). Defaults to `bots` so a
+    * caller that doesn't separate the two pools sees today's behavior:
+    * hiding bots hides them from Ready too. */
+   botsForReady?: DerivedPull[];
    /** merged/closed pulls in the loaded window — only `.length` feeds the
     * lanes below (the "recently closed" fold's count, the empty-board check);
     * Review.tsx still renders the array itself, straight from its own prop. */
@@ -140,6 +150,7 @@ export function buildReviewLanes(input: ReviewLanesInput): ReviewLanes {
    const {
       pulls,
       bots,
+      botsForReady = bots,
       closed,
       napping,
       changed,
@@ -307,9 +318,12 @@ export function buildReviewLanes(input: ReviewLanesInput): ReviewLanes {
    // one button-press from done. It earns a real lane in Pick up next rather
    // than a fold — and bot PRs that reach ready join it, since a human has to
    // land them. Longest-waiting first: the ones most likely forgotten.
+   // botsForReady (not `bots`) so this lane keeps showing merge-ready bot
+   // PRs even when "Ignore bot PRs" has emptied `bots` out of the queue
+   // tail and the bot fold below.
    const ready = [
       ...others.filter(p => p.status === 'ready'),
-      ...bots.filter(p => p.status === 'ready'),
+      ...botsForReady.filter(p => p.status === 'ready'),
    ].sort((a, b) => b.ageDays - a.ageDays);
 
    const needsQa = teamFirst(qaSort(qaPool.filter(p => isPrimaryRepo(p.data.repo))), team);

--- a/frontend-v2/src/model/reviewLanes.ts
+++ b/frontend-v2/src/model/reviewLanes.ts
@@ -456,8 +456,12 @@ export function buildReviewLanes(input: ReviewLanesInput): ReviewLanes {
       botRest.length +
       closed.length;
 
-   // bots/shipped stay reachable even when no human PRs need review
-   const empty = !pulls.length && !bots.length && !closed.length;
+   // bots/shipped stay reachable even when no human PRs need review. Checks
+   // botsForReady too: a merge-ready bot can sit in `ready` via botsForReady
+   // while `bots` itself is empty ("Ignore bot PRs" hid it from the queue/
+   // fold), and that bot must not be declared "nothing to see" out from
+   // under it.
+   const empty = !pulls.length && !bots.length && !closed.length && !botsForReady.length;
 
    return {
       yourMove,

--- a/frontend-v2/src/model/shipped.test.ts
+++ b/frontend-v2/src/model/shipped.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { PullData } from '../../../shared/types';
 import { rankShipped, shipRelevance, shippedToast } from './shipped';
+import { TOAST_PULLS_SHOWN } from './toast';
 
 /** A closed PullData carrying only the fields shipped ranking reads. */
 function dp(o: {
@@ -114,6 +115,23 @@ describe('shippedToast', () => {
       expect(toast?.title).toBe('3 shipped while you were away');
       expect(toast?.body).toContain('1 yours');
       expect(toast?.body).toContain('2 you reviewed');
+   });
+
+   it('lists the shipped pulls ranked, for the renderer to show a top few plus an overflow count', () => {
+      const shipped = [1, 2, 3, 4, 5].map(number =>
+         dp({ number, author: 'me', closedAt: `2026-0${number}-01T00:00:00Z` })
+      );
+      const toast = shippedToast(shipped, 'me');
+      // no single `pull` for a batch; the list carries every relevant pull,
+      // ranked newest-closed-first (all tie on tier here, since every one is
+      // 'yours') so the renderer's top-N slice and "+N more" fold both read
+      // off the same ranked array instead of a separately-tracked count
+      expect(toast?.pull).toBeUndefined();
+      expect(toast?.pulls?.map(p => p.number)).toEqual([5, 4, 3, 2, 1]);
+      const shown = toast?.pulls?.slice(0, TOAST_PULLS_SHOWN) ?? [];
+      expect(shown.map(p => p.number)).toEqual([5, 4, 3]);
+      const overflow = (toast?.pulls?.length ?? 0) - TOAST_PULLS_SHOWN;
+      expect(overflow).toBe(2);
    });
 
    it('re-fires on a newer merge but is stable for the same backlog', () => {

--- a/frontend-v2/src/model/shipped.ts
+++ b/frontend-v2/src/model/shipped.ts
@@ -75,8 +75,13 @@ export function shippedToast(shipped: PullData[], me: string): Toast | null {
                ? 'Your PR landed.'
                : 'One you reviewed landed.'
             : breakdown,
-      // a single relevant merge gets a link to it; a batch stays a summary
+      // a single relevant merge gets a link to it; a batch lists the ranked
+      // PRs instead (the renderer shows the first few and folds the rest
+      // into a "+N more" line, per TOAST_PULLS_SHOWN) so a multi-ship
+      // catch-up names real work instead of collapsing to a bare count
       pull: n === 1 ? { repo: top.repo, number: top.number, title: top.title } : undefined,
+      pulls:
+         n > 1 ? ranked.map(p => ({ repo: p.repo, number: p.number, title: p.title })) : undefined,
       dedupeKey: `shipped:${latest}:${n}`,
    };
 }

--- a/frontend-v2/src/model/status.test.ts
+++ b/frontend-v2/src/model/status.test.ts
@@ -298,6 +298,17 @@ describe('changesRequestedBy / engagedNoStamp', () => {
       expect(d.changesRequestedBy).toEqual(['grumpy']);
    });
 
+   it('changesRequestedBy excludes bots', () => {
+      const p = withStatus({
+         unstamped_reviewers: [
+            { login: 'grumpy', state: 'CHANGES_REQUESTED', date: 1 },
+            { login: 'dependabot[bot]', state: 'CHANGES_REQUESTED', date: 2 },
+         ],
+      });
+      const d = derive(p, undefined, NOW);
+      expect(d.changesRequestedBy).toEqual(['grumpy']);
+   });
+
    it('engagedNoStamp includes unstamped reviewers of any verdict', () => {
       const p = withStatus({
          unstamped_reviewers: [

--- a/frontend-v2/src/model/toast.ts
+++ b/frontend-v2/src/model/toast.ts
@@ -1,5 +1,10 @@
 export type ToastTone = 'reward' | 'nag' | 'info';
 
+/** How many of a batched toast's `pulls` render as links before the rest
+ * fold into a "+N more" line. Shared by the toast stack and the notification
+ * panel so a batched nudge lists the same number of PRs in both places. */
+export const TOAST_PULLS_SHOWN = 3;
+
 /**
  * The reusable toast contract. Both the gamified cheers evaluator
  * (model/cheers) and the shipped catch-up (model/shipped) produce these;
@@ -30,6 +35,13 @@ export interface Toast {
     * on GitHub if off-screen), and the card renders its number + title as a
     * link, so a toast says WHICH pull, not just a bare #number */
    pull?: { repo: string; number: number; title?: string };
+   /** for a batched toast covering more than one PR (e.g. the shipped
+    * catch-up when several landed at once): the pulls it covers, ranked
+    * most-relevant-first. The renderer shows the first `TOAST_PULLS_SHOWN`
+    * as links and folds the rest into a "+N more" line, the same overflow
+    * pattern the board's other lists use. Falls back to the singular `pull`
+    * above when absent or empty. */
+   pulls?: { repo: string; number: number; title?: string }[];
    /** stable id so the same logical toast isn't re-fired every board tick */
    dedupeKey?: string;
    /** per-toast lifetime override (ms); falls back to the tone default */

--- a/frontend-v2/src/store.test.ts
+++ b/frontend-v2/src/store.test.ts
@@ -44,7 +44,7 @@ const AT = 1_000_000; // epoch secs the pull was snoozed
 const WITHIN = AT + 60; // "now", inside the 24h window
 const KEY = pullKey({ repo: 'org/repo', number: 7 });
 const rec = (o: Partial<SnoozeRecord> = {}): Record<string, SnoozeRecord> => ({
-   [KEY]: { at: AT, comments: 0, reviews: 0, ...o },
+   [KEY]: { at: AT, comments: 0, cr: 0, qa: 0, unstamped: 0, ...o },
 });
 
 describe('isSnoozed', () => {
@@ -63,11 +63,27 @@ describe('isSnoozed', () => {
    });
 
    it('wakes on a new review: a CR stamp or an unstamped verdict', () => {
+      expect(isSnoozed(pull({ updatedAtEpoch: AT - 100, cr: 1 }), rec({ cr: 0 }), WITHIN)).toBe(
+         false
+      );
       expect(
-         isSnoozed(pull({ updatedAtEpoch: AT - 100, cr: 1 }), rec({ reviews: 0 }), WITHIN)
+         isSnoozed(pull({ updatedAtEpoch: AT - 100, unstamped: 1 }), rec({ unstamped: 0 }), WITHIN)
       ).toBe(false);
+   });
+
+   it('wakes when a reviewer moves from COMMENTED to APPROVED while snoozed', () => {
+      // at snooze time: one human COMMENTED verdict sitting in
+      // unstamped_reviewers, no CR stamp yet. By the time of this check they
+      // approved: cr climbs to 1 and unstamped drops to 0. A single combined
+      // "reviews" counter (cr+qa+unstamped) would read this as unchanged
+      // (1 -> 1) and stay asleep; cr and unstamped tracked separately must
+      // each be compared to their own baseline so the cr climb alone wakes it.
       expect(
-         isSnoozed(pull({ updatedAtEpoch: AT - 100, unstamped: 1 }), rec({ reviews: 0 }), WITHIN)
+         isSnoozed(
+            pull({ updatedAtEpoch: AT - 100, cr: 1, unstamped: 0 }),
+            rec({ cr: 0, unstamped: 1 }),
+            WITHIN
+         )
       ).toBe(false);
    });
 
@@ -90,16 +106,12 @@ describe('isSnoozed', () => {
       // pull; bot activity must never drive the human-review nudge, so
       // neither should wake a snoozed row.
       expect(
-         isSnoozed(
-            pull({ updatedAtEpoch: AT - 100, cr: ['claude[bot]'] }),
-            rec({ reviews: 0 }),
-            WITHIN
-         )
+         isSnoozed(pull({ updatedAtEpoch: AT - 100, cr: ['claude[bot]'] }), rec({ cr: 0 }), WITHIN)
       ).toBe(true);
       expect(
          isSnoozed(
             pull({ updatedAtEpoch: AT - 100, unstamped: ['claude[bot]'] }),
-            rec({ reviews: 0 }),
+            rec({ unstamped: 0 }),
             WITHIN
          )
       ).toBe(true);
@@ -109,7 +121,7 @@ describe('isSnoozed', () => {
       expect(
          isSnoozed(
             pull({ updatedAtEpoch: AT - 100, cr: ['claude[bot]', 'human'] }),
-            rec({ reviews: 0 }),
+            rec({ cr: 0 }),
             WITHIN
          )
       ).toBe(false);

--- a/frontend-v2/src/store.test.ts
+++ b/frontend-v2/src/store.test.ts
@@ -5,13 +5,18 @@ import { isSnoozed, type SnoozeRecord } from './store';
 
 // isSnoozed reads only repo/number/updated_at and a few status counts, so a
 // minimal pull is enough; the outer cast keeps the fixture to what it touches.
+// cr/qa/unstamped take either a plain count (all "human" logins) or an
+// explicit login list, so a test can mark specific entries as bots.
 function pull(o: {
    updatedAtEpoch: number;
    comments?: number;
-   cr?: number;
-   qa?: number;
-   unstamped?: number;
+   humanComments?: number;
+   cr?: number | string[];
+   qa?: number | string[];
+   unstamped?: number | string[];
 }): PullData {
+   const logins = (n: number | string[] | undefined, fallback: string) =>
+      Array.isArray(n) ? n : Array.from({ length: n ?? 0 }, () => fallback);
    return {
       repo: 'org/repo',
       number: 7,
@@ -19,14 +24,15 @@ function pull(o: {
       status: {
          cr_req: 2,
          qa_req: 1,
-         allCR: Array.from({ length: o.cr ?? 0 }, () => ({})),
-         allQA: Array.from({ length: o.qa ?? 0 }, () => ({})),
+         allCR: logins(o.cr, 'human').map(login => ({ data: { user: { login } } })),
+         allQA: logins(o.qa, 'human').map(login => ({ data: { user: { login } } })),
          dev_block: [],
          deploy_block: [],
          commit_statuses: [],
          comment_count: o.comments ?? 0,
-         unstamped_reviewers: Array.from({ length: o.unstamped ?? 0 }, () => ({
-            login: 'x',
+         human_comment_count: o.humanComments,
+         unstamped_reviewers: logins(o.unstamped, 'human').map(login => ({
+            login,
             state: 'COMMENTED',
             date: 0,
          })),
@@ -77,5 +83,53 @@ describe('isSnoozed', () => {
 
    it('expires after the 24h window', () => {
       expect(isSnoozed(pull({ updatedAtEpoch: AT - 100 }), rec(), AT + 24 * 3600 + 1)).toBe(false);
+   });
+
+   it('a bot review or comment-only verdict does not wake a snooze', () => {
+      // claude[bot] posts a CR stamp and a COMMENTED verdict on the same
+      // pull; bot activity must never drive the human-review nudge, so
+      // neither should wake a snoozed row.
+      expect(
+         isSnoozed(
+            pull({ updatedAtEpoch: AT - 100, cr: ['claude[bot]'] }),
+            rec({ reviews: 0 }),
+            WITHIN
+         )
+      ).toBe(true);
+      expect(
+         isSnoozed(
+            pull({ updatedAtEpoch: AT - 100, unstamped: ['claude[bot]'] }),
+            rec({ reviews: 0 }),
+            WITHIN
+         )
+      ).toBe(true);
+   });
+
+   it('still wakes on a human review alongside a bot one', () => {
+      expect(
+         isSnoozed(
+            pull({ updatedAtEpoch: AT - 100, cr: ['claude[bot]', 'human'] }),
+            rec({ reviews: 0 }),
+            WITHIN
+         )
+      ).toBe(false);
+   });
+
+   it('prefers human_comment_count over comment_count for the wake signal', () => {
+      // The server counts a bot comment in comment_count but not in
+      // human_comment_count; only the human-only count should matter.
+      expect(
+         isSnoozed(
+            pull({ updatedAtEpoch: AT - 100, comments: 3, humanComments: 2 }),
+            rec({ comments: 2 }),
+            WITHIN
+         )
+      ).toBe(true);
+   });
+
+   it('falls back to comment_count when an older server omits human_comment_count', () => {
+      expect(
+         isSnoozed(pull({ updatedAtEpoch: AT - 100, comments: 3 }), rec({ comments: 2 }), WITHIN)
+      ).toBe(false);
    });
 });

--- a/frontend-v2/src/store.test.ts
+++ b/frontend-v2/src/store.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { pullKey } from '../../shared/format';
+import type { PullData } from '../../shared/types';
+import { isSnoozed, type SnoozeRecord } from './store';
+
+// isSnoozed reads only repo/number/updated_at and a few status counts, so a
+// minimal pull is enough; the outer cast keeps the fixture to what it touches.
+function pull(o: {
+   updatedAtEpoch: number;
+   comments?: number;
+   cr?: number;
+   qa?: number;
+   unstamped?: number;
+}): PullData {
+   return {
+      repo: 'org/repo',
+      number: 7,
+      updated_at: new Date(o.updatedAtEpoch * 1000).toISOString(),
+      status: {
+         cr_req: 2,
+         qa_req: 1,
+         allCR: Array.from({ length: o.cr ?? 0 }, () => ({})),
+         allQA: Array.from({ length: o.qa ?? 0 }, () => ({})),
+         dev_block: [],
+         deploy_block: [],
+         commit_statuses: [],
+         comment_count: o.comments ?? 0,
+         unstamped_reviewers: Array.from({ length: o.unstamped ?? 0 }, () => ({
+            login: 'x',
+            state: 'COMMENTED',
+            date: 0,
+         })),
+      },
+   } as unknown as PullData;
+}
+
+const AT = 1_000_000; // epoch secs the pull was snoozed
+const WITHIN = AT + 60; // "now", inside the 24h window
+const KEY = pullKey({ repo: 'org/repo', number: 7 });
+const rec = (o: Partial<SnoozeRecord> = {}): Record<string, SnoozeRecord> => ({
+   [KEY]: { at: AT, comments: 0, reviews: 0, ...o },
+});
+
+describe('isSnoozed', () => {
+   it('stays snoozed when nothing changed since the snooze', () => {
+      expect(isSnoozed(pull({ updatedAtEpoch: AT - 100 }), rec(), WITHIN)).toBe(true);
+   });
+
+   it('is not snoozed without a record for the pull', () => {
+      expect(isSnoozed(pull({ updatedAtEpoch: AT - 100 }), {}, WITHIN)).toBe(false);
+   });
+
+   it('wakes when the comment count climbs above the baseline', () => {
+      expect(
+         isSnoozed(pull({ updatedAtEpoch: AT - 100, comments: 3 }), rec({ comments: 2 }), WITHIN)
+      ).toBe(false);
+   });
+
+   it('wakes on a new review: a CR stamp or an unstamped verdict', () => {
+      expect(
+         isSnoozed(pull({ updatedAtEpoch: AT - 100, cr: 1 }), rec({ reviews: 0 }), WITHIN)
+      ).toBe(false);
+      expect(
+         isSnoozed(pull({ updatedAtEpoch: AT - 100, unstamped: 1 }), rec({ reviews: 0 }), WITHIN)
+      ).toBe(false);
+   });
+
+   it('does not wake when a count merely drops (a deleted comment fails safe)', () => {
+      expect(
+         isSnoozed(pull({ updatedAtEpoch: AT - 100, comments: 1 }), rec({ comments: 3 }), WITHIN)
+      ).toBe(true);
+   });
+
+   it('wakes on a push that moved updated_at past the snooze', () => {
+      expect(isSnoozed(pull({ updatedAtEpoch: AT + 100 }), rec(), WITHIN)).toBe(false);
+   });
+
+   it('expires after the 24h window', () => {
+      expect(isSnoozed(pull({ updatedAtEpoch: AT - 100 }), rec(), AT + 24 * 3600 + 1)).toBe(false);
+   });
+});

--- a/frontend-v2/src/store.ts
+++ b/frontend-v2/src/store.ts
@@ -116,36 +116,56 @@ export function isFresh(d: Pick<PullData, 'updated_at'>, lastSeenAt: number) {
 // next. Two kinds of activity count. A push, edit, or label moves updated_at
 // (the classic check). A new comment or review does NOT move updated_at
 // (those arrive on their own webhook path), so the snooze also records the
-// comment and review counts at snooze time and wakes when either climbs.
-// Counts only: the wire has no per-event author, so your own comment wakes it
-// too, the same way your own push already does.
-export type SnoozeRecord = { at: number; comments: number; reviews: number };
+// comment count plus CR/QA/unstamped counts at snooze time and wakes when
+// any of them climbs. The three review counts are kept separate rather than
+// summed: a reviewer moving from COMMENTED to APPROVED drops unstamped by
+// one and raises cr by one, a wash under one combined total that would leave
+// a snooze asleep through exactly the transition it should wake for. Counts
+// only: the wire has no per-event author, so your own comment wakes it too,
+// the same way your own push already does.
+export type SnoozeRecord = {
+   at: number;
+   comments: number;
+   cr: number;
+   qa: number;
+   unstamped: number;
+};
 const SNOOZED_KEY = 'pd2.snoozed';
 const SNOOZE_SECS = 24 * 3600;
 // the comment/review signals that wake a snooze, read off the pull's status.
 // Bot activity (claude[bot]'s review, a CI bot's comment) must never wake a
 // snooze on its own, so every count here excludes bot logins first: prefer
-// the server's human-only comment count when it's sent, and re-derive the
-// review count from the same isBotLogin the board uses everywhere else.
+// the server's human-only comment count when it's sent, and re-derive cr/qa/
+// unstamped from the same isBotLogin the board uses everywhere else.
 const snoozeActivity = (d: Pick<PullData, 'status'>) => {
    const isHuman = (login: string) => !isBotLogin(login, extraBots);
    return {
       comments: d.status.human_comment_count ?? d.status.comment_count ?? 0,
-      reviews:
-         d.status.allCR.filter(s => isHuman(s.data.user.login)).length +
-         d.status.allQA.filter(s => isHuman(s.data.user.login)).length +
-         (d.status.unstamped_reviewers?.filter(r => isHuman(r.login)).length ?? 0),
+      cr: d.status.allCR.filter(s => isHuman(s.data.user.login)).length,
+      qa: d.status.allQA.filter(s => isHuman(s.data.user.login)).length,
+      unstamped: d.status.unstamped_reviewers?.filter(r => isHuman(r.login)).length ?? 0,
    };
 };
 let snoozed: Record<string, SnoozeRecord> = {};
 try {
    const raw = JSON.parse(readStorage(SNOOZED_KEY) ?? '{}') ?? {};
-   // clean cut: only the {at, comments, reviews} shape is supported. A
-   // pre-baseline entry (a bare epoch number from before this field) is
-   // dropped, so the pull reappears once and you re-snooze it if you still want.
-   for (const [k, v] of Object.entries(raw))
-      if (v && typeof v === 'object' && typeof (v as { at?: unknown }).at === 'number')
-         snoozed[k] = v as SnoozeRecord;
+   // clean cut: only the full {at, comments, cr, qa, unstamped} shape is
+   // supported. A half-shaped entry (the old {at, comments, reviews} baseline,
+   // or anything from before it) is dropped, so the pull reappears once and
+   // you re-snooze it if you still want.
+   for (const [k, v] of Object.entries(raw)) {
+      const r = v as Partial<SnoozeRecord> | null;
+      if (
+         r &&
+         typeof r === 'object' &&
+         typeof r.at === 'number' &&
+         typeof r.comments === 'number' &&
+         typeof r.cr === 'number' &&
+         typeof r.qa === 'number' &&
+         typeof r.unstamped === 'number'
+      )
+         snoozed[k] = r as SnoozeRecord;
+   }
 } catch {
    snoozed = {};
 }
@@ -185,7 +205,8 @@ export function isSnoozed(
    if (now >= rec.at + SNOOZE_SECS) return false;
    if (epoch(d.updated_at) > rec.at) return false;
    const a = snoozeActivity(d);
-   if (a.comments > rec.comments || a.reviews > rec.reviews) return false;
+   if (a.comments > rec.comments || a.cr > rec.cr || a.qa > rec.qa || a.unstamped > rec.unstamped)
+      return false;
    return true;
 }
 

--- a/frontend-v2/src/store.ts
+++ b/frontend-v2/src/store.ts
@@ -6,6 +6,7 @@ import {
    type DerivedPull,
    type Weight,
 } from '../../shared/model/status';
+import { isBotLogin } from '../../shared/model/visibility';
 import { getSettings, subscribeSettings } from './settings';
 import { epoch, pullKey } from '../../shared/format';
 import { readStorage, writeStorage } from './storage';
@@ -121,12 +122,21 @@ export function isFresh(d: Pick<PullData, 'updated_at'>, lastSeenAt: number) {
 export type SnoozeRecord = { at: number; comments: number; reviews: number };
 const SNOOZED_KEY = 'pd2.snoozed';
 const SNOOZE_SECS = 24 * 3600;
-// the comment/review signals that wake a snooze, read off the pull's status
-const snoozeActivity = (d: Pick<PullData, 'status'>) => ({
-   comments: d.status.comment_count ?? 0,
-   reviews:
-      d.status.allCR.length + d.status.allQA.length + (d.status.unstamped_reviewers?.length ?? 0),
-});
+// the comment/review signals that wake a snooze, read off the pull's status.
+// Bot activity (claude[bot]'s review, a CI bot's comment) must never wake a
+// snooze on its own, so every count here excludes bot logins first: prefer
+// the server's human-only comment count when it's sent, and re-derive the
+// review count from the same isBotLogin the board uses everywhere else.
+const snoozeActivity = (d: Pick<PullData, 'status'>) => {
+   const isHuman = (login: string) => !isBotLogin(login, extraBots);
+   return {
+      comments: d.status.human_comment_count ?? d.status.comment_count ?? 0,
+      reviews:
+         d.status.allCR.filter(s => isHuman(s.data.user.login)).length +
+         d.status.allQA.filter(s => isHuman(s.data.user.login)).length +
+         (d.status.unstamped_reviewers?.filter(r => isHuman(r.login)).length ?? 0),
+   };
+};
 let snoozed: Record<string, SnoozeRecord> = {};
 try {
    const raw = JSON.parse(readStorage(SNOOZED_KEY) ?? '{}') ?? {};

--- a/frontend-v2/src/store.ts
+++ b/frontend-v2/src/store.ts
@@ -33,9 +33,10 @@ export interface Snapshot {
    lastPayloadAt: number;
    /** epoch secs of the last Clear — the "Recently updated" baseline */
    lastSeen: number;
-   /** pull key → epoch secs it was snoozed: hidden for a day or until it
-    * changes. Persisted per-browser. */
-   snoozed: Readonly<Record<string, number>>;
+   /** pull key → snooze record (when it was snoozed, plus the comment and
+    * review baseline that wakes it): hidden for a day or until it changes.
+    * Persisted per-browser. */
+   snoozed: Readonly<Record<string, SnoozeRecord>>;
    /** "Refresh all" in progress (or just finished): how many of the pulls
     * queued at kickoff have reported back. Null when no refresh is running. */
    refreshProgress: { done: number; total: number } | null;
@@ -109,24 +110,43 @@ export function isFresh(d: Pick<PullData, 'updated_at'>, lastSeenAt: number) {
    return epoch(d.updated_at) > lastSeenAt;
 }
 
-// Snooze: "not today" for one PR. A snooze lasts a day, and any change to
-// the pull (a push, a comment — anything that moves updated_at) voids it
-// early: punting a PR must never hide what happens to it next.
+// Snooze: "not today" for one PR. A snooze lasts a day, and any activity on
+// the pull voids it early: punting a PR must never hide what happens to it
+// next. Two kinds of activity count. A push, edit, or label moves updated_at
+// (the classic check). A new comment or review does NOT move updated_at
+// (those arrive on their own webhook path), so the snooze also records the
+// comment and review counts at snooze time and wakes when either climbs.
+// Counts only: the wire has no per-event author, so your own comment wakes it
+// too, the same way your own push already does.
+export type SnoozeRecord = { at: number; comments: number; reviews: number };
 const SNOOZED_KEY = 'pd2.snoozed';
 const SNOOZE_SECS = 24 * 3600;
-let snoozed: Record<string, number> = {};
+// the comment/review signals that wake a snooze, read off the pull's status
+const snoozeActivity = (d: Pick<PullData, 'status'>) => ({
+   comments: d.status.comment_count ?? 0,
+   reviews:
+      d.status.allCR.length + d.status.allQA.length + (d.status.unstamped_reviewers?.length ?? 0),
+});
+let snoozed: Record<string, SnoozeRecord> = {};
 try {
-   snoozed = JSON.parse(readStorage(SNOOZED_KEY) ?? '{}') ?? {};
+   const raw = JSON.parse(readStorage(SNOOZED_KEY) ?? '{}') ?? {};
+   // clean cut: only the {at, comments, reviews} shape is supported. A
+   // pre-baseline entry (a bare epoch number from before this field) is
+   // dropped, so the pull reappears once and you re-snooze it if you still want.
+   for (const [k, v] of Object.entries(raw))
+      if (v && typeof v === 'object' && typeof (v as { at?: unknown }).at === 'number')
+         snoozed[k] = v as SnoozeRecord;
 } catch {
    snoozed = {};
 }
 const saveSnoozed = () => {
    const now = Date.now() / 1000;
-   for (const [k, at] of Object.entries(snoozed)) if (now > at + SNOOZE_SECS) delete snoozed[k];
+   for (const [k, rec] of Object.entries(snoozed))
+      if (now > rec.at + SNOOZE_SECS) delete snoozed[k];
    writeStorage(SNOOZED_KEY, JSON.stringify(snoozed));
 };
-export function snoozePull(key: string) {
-   snoozed[key] = Date.now() / 1000;
+export function snoozePull(pull: Pick<PullData, 'repo' | 'number' | 'status'>) {
+   snoozed[pullKey(pull)] = { at: Date.now() / 1000, ...snoozeActivity(pull) };
    saveSnoozed();
    schedulePublish();
 }
@@ -142,15 +162,21 @@ export function clearSnoozes() {
    schedulePublish();
 }
 
-/** Snoozed and nothing has happened since: still hidden. */
+/** Snoozed and nothing has happened since: still hidden. Wakes on a push
+ * (updated_at moved) or a new comment or review (a count above the baseline
+ * captured at snooze time). */
 export function isSnoozed(
-   d: Pick<PullData, 'repo' | 'number' | 'updated_at'>,
-   snoozedAt: Readonly<Record<string, number>>,
+   d: Pick<PullData, 'repo' | 'number' | 'updated_at' | 'status'>,
+   snoozedAt: Readonly<Record<string, SnoozeRecord>>,
    now: number = Date.now() / 1000
 ) {
-   const at = snoozedAt[pullKey(d)];
-   if (at == null) return false;
-   return now < at + SNOOZE_SECS && epoch(d.updated_at) <= at;
+   const rec = snoozedAt[pullKey(d)];
+   if (rec == null) return false;
+   if (now >= rec.at + SNOOZE_SECS) return false;
+   if (epoch(d.updated_at) > rec.at) return false;
+   const a = snoozeActivity(d);
+   if (a.comments > rec.comments || a.reviews > rec.reviews) return false;
+   return true;
 }
 
 let snapshot: Snapshot = {

--- a/frontend-v2/src/styles.css
+++ b/frontend-v2/src/styles.css
@@ -726,6 +726,29 @@ label:has(> input:not(:disabled)) {
   animation: spin-once 400ms var(--ease-quart);
 }
 
+/* the empty-search exclamation punching in after the glass draws — one shot,
+   scale + fade from its own center (fill-box), delayed so it lands last */
+@keyframes alert-pop {
+  from {
+    opacity: 0;
+    scale: 0.4;
+  }
+  to {
+    opacity: 1;
+    scale: 1;
+  }
+}
+.alert-pop {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: alert-pop 380ms var(--ease-quint) 300ms backwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .alert-pop {
+    animation: none;
+  }
+}
+
 @keyframes nod {
   50% {
     scale: 1.25;

--- a/frontend-v2/src/toasts.tsx
+++ b/frontend-v2/src/toasts.tsx
@@ -584,7 +584,7 @@ function ToastCard({ toast, onDismiss }: { toast: LiveToast; onDismiss: (id: num
                      onClick={e => e.stopPropagation()}
                      className="mt-0.5 block text-xs font-medium text-brand hover:underline"
                   >
-                     #{toast.pull.number}
+                     {shortRepo(toast.pull.repo)}#{toast.pull.number}
                      {toast.pull.title ? ` ${toast.pull.title}` : ''}
                   </a>
                )

--- a/frontend-v2/src/toasts.tsx
+++ b/frontend-v2/src/toasts.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { X } from 'lucide-react';
-import { githubUrl, rowDomId } from '../../shared/format';
+import { githubUrl, pullKey, rowDomId, shortRepo } from '../../shared/format';
 import { Icon } from './components/Icon';
 import {
    type CheerBaseline,
@@ -12,7 +12,7 @@ import {
    type ToastKind,
 } from './model/cheers';
 import type { DerivedPull } from '../../shared/model/status';
-import type { Toast } from './model/toast';
+import { type Toast, TOAST_PULLS_SHOWN } from './model/toast';
 import { getSettings } from './settings';
 import { readSessionStorage, writeSessionStorage } from './storage';
 import type { PullData } from '../../shared/types';
@@ -554,21 +554,42 @@ function ToastCard({ toast, onDismiss }: { toast: LiveToast; onDismiss: (id: num
                )}
                {toast.title}
             </span>
-            {toast.pull && (
-               <a
-                  href={githubUrl(toast.pull.repo, toast.pull.number)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={e => e.stopPropagation()}
-                  className="mt-0.5 block truncate text-xs font-medium text-brand hover:underline"
-               >
-                  #{toast.pull.number}
-                  {toast.pull.title ? ` ${toast.pull.title}` : ''}
-               </a>
+            {toast.pulls && toast.pulls.length > 0 ? (
+               <span className="mt-0.5 flex flex-col gap-0.5">
+                  {toast.pulls.slice(0, TOAST_PULLS_SHOWN).map(p => (
+                     <a
+                        key={pullKey(p)}
+                        href={githubUrl(p.repo, p.number)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={e => e.stopPropagation()}
+                        className="block text-xs font-medium text-brand hover:underline"
+                     >
+                        {shortRepo(p.repo)}#{p.number}
+                        {p.title ? ` ${p.title}` : ''}
+                     </a>
+                  ))}
+                  {toast.pulls.length > TOAST_PULLS_SHOWN && (
+                     <span className="block text-xs text-ink-3">
+                        +{toast.pulls.length - TOAST_PULLS_SHOWN} more
+                     </span>
+                  )}
+               </span>
+            ) : (
+               toast.pull && (
+                  <a
+                     href={githubUrl(toast.pull.repo, toast.pull.number)}
+                     target="_blank"
+                     rel="noopener noreferrer"
+                     onClick={e => e.stopPropagation()}
+                     className="mt-0.5 block text-xs font-medium text-brand hover:underline"
+                  >
+                     #{toast.pull.number}
+                     {toast.pull.title ? ` ${toast.pull.title}` : ''}
+                  </a>
+               )
             )}
-            {toast.body && (
-               <span className="mt-0.5 line-clamp-2 block text-xs text-ink-2">{toast.body}</span>
-            )}
+            {toast.body && <span className="mt-0.5 block text-xs text-ink-2">{toast.body}</span>}
             {toast.actionLabel && toast.onAction && (
                <button
                   type="button"

--- a/frontend-v2/src/views/Ci.tsx
+++ b/frontend-v2/src/views/Ci.tsx
@@ -101,7 +101,9 @@ export function Ci({ pulls, opts }: { pulls: DerivedPull[]; opts: RowOptions }) 
    const noChecks = useMemo(() => pulls.filter(p => p.ci === 'none'), [pulls]);
 
    if (!pulls.length) {
-      return <EmptyState title="All clear" sub="No open PRs match your filters." />;
+      return (
+         <EmptyState variant="search" title="No matches" sub="No open PRs match your filters." />
+      );
    }
    if (!withChecks.length) {
       return <EmptyState title="No checks to show" sub="None of these PRs run CI checks." />;

--- a/frontend-v2/src/views/Classic.tsx
+++ b/frontend-v2/src/views/Classic.tsx
@@ -84,7 +84,9 @@ function Column({
 export function Classic({ pulls, opts }: { pulls: DerivedPull[]; opts: RowOptions }) {
    const me = opts.me;
    if (!pulls.length) {
-      return <EmptyState title="All clear" sub="No open PRs match your filters." />;
+      return (
+         <EmptyState variant="search" title="No matches" sub="No open PRs match your filters." />
+      );
    }
    const base = [...pulls].sort(defaultCompare(me));
 

--- a/frontend-v2/src/views/Review.tsx
+++ b/frontend-v2/src/views/Review.tsx
@@ -1,5 +1,5 @@
 import type { DerivedPull } from '../../../shared/model/status';
-import { ago, pullKey, shortRepo } from '../../../shared/format';
+import { pullKey, shortRepo } from '../../../shared/format';
 import { useNames } from '../model/names';
 import { matchedRegions } from '../model/regions';
 import { buildReviewLanes } from '../model/reviewLanes';
@@ -214,7 +214,7 @@ export function Review({
          )}
          <Lane
             title="Recently updated"
-            sub={`new or updated in the last ${ago(opts.lastSeen)}`}
+            sub={`review-relevant activity from the last ${RECENT_MAX_AGE_DAYS} days`}
             pulls={lanes.changed}
             cap={8}
             opts={opts}

--- a/frontend-v2/src/views/Review.tsx
+++ b/frontend-v2/src/views/Review.tsx
@@ -240,9 +240,10 @@ export function Review({
          {repoPriority.length > 0 ? (
             // the owner's priority-and-cap model: contiguous per-repo blocks in
             // the Settings repo order, each block score-ranked inside and
-            // flood-bounded by the per-repo cap. Starving PRs pierce the
-            // partition — the fairness backstop can't sit below a repo the
-            // viewer ranked last, or "surface the other repos" becomes a lie.
+            // flood-bounded by the per-repo cap. Starving PRs lead the "Starving"
+            // fold as a highlight, but also stay in their own repo block below —
+            // the fairness backstop can't be hidden behind a repo the viewer
+            // ranked last, or "surface the other repos" becomes a lie.
             <Lane
                title="Review queue"
                sub={
@@ -265,6 +266,10 @@ export function Review({
                         more” so one busy repo can’t take the whole screen.
                      </p>
                      <p>PRs you claim stay in the queue and also appear in Waiting on you.</p>
+                     <p>
+                        Starving PRs and PRs in your code regions still show up in their repo block
+                        below; the call-outs above are copies, not removals.
+                     </p>
                   </SubDoor>
                }
                pulls={[]}
@@ -321,6 +326,10 @@ export function Review({
                         sink to the bottom.
                      </p>
                      <p>PRs you claim stay in the queue and also appear in Waiting on you.</p>
+                     <p>
+                        PRs in your code regions still show up in the queue below; the call-out
+                        above is a copy, not a removal.
+                     </p>
                   </SubDoor>
                }
                pulls={lanes.queue}

--- a/frontend-v2/src/views/Review.tsx
+++ b/frontend-v2/src/views/Review.tsx
@@ -28,11 +28,16 @@ import { ClosedRow } from '../components/ClosedRow';
 export function Review({
    pulls: allPulls,
    bots: allBots,
+   botsForReady: allBotsForReady,
    closed,
    opts,
 }: {
    pulls: DerivedPull[];
    bots: DerivedPull[];
+   /** the hideBots-bypassing bot pool (app.tsx) that keeps Ready-to-merge
+    * showing merge-ready bot PRs even when `bots` has been emptied by
+    * "Ignore bot PRs" — see model/reviewLanes.ts's botsForReady. */
+   botsForReady: DerivedPull[];
    closed: PullData[];
    opts: RowOptions;
 }) {
@@ -46,9 +51,21 @@ export function Review({
    // lens still shows the pull. Snoozed rows collect in their own section at
    // the bottom of the board instead of vanishing into Settings.
    const { snoozed } = usePulldasher();
-   const napping = [...allPulls, ...allBots].filter(p => isSnoozed(p.data, snoozed));
+   // allBotsForReady can hold a bot allBots no longer does ("Ignore bot PRs"
+   // pulled it out of the human-review surfaces) — folded in here too, deduped
+   // by key, so snoozing a bot straight off the Ready-to-merge lane still
+   // parks it in "Snoozed by you" instead of making it vanish with no undo.
+   const nappingKeys = new Set<string>();
+   const napping = [...allPulls, ...allBots, ...allBotsForReady].filter(p => {
+      if (!isSnoozed(p.data, snoozed)) return false;
+      const k = pullKey(p.data);
+      if (nappingKeys.has(k)) return false;
+      nappingKeys.add(k);
+      return true;
+   });
    const pulls = allPulls.filter(p => !isSnoozed(p.data, snoozed));
    const bots = allBots.filter(p => !isSnoozed(p.data, snoozed));
+   const botsForReady = allBotsForReady.filter(p => !isSnoozed(p.data, snoozed));
 
    // Recently updated: your review work that moved recently, newest first.
    // Bounded two ways so a quiet board stops resurfacing stale bumps — since
@@ -73,6 +90,7 @@ export function Review({
    const lanes = buildReviewLanes({
       pulls,
       bots,
+      botsForReady,
       closed,
       napping,
       changed,

--- a/frontend-v2/src/views/Review.tsx
+++ b/frontend-v2/src/views/Review.tsx
@@ -215,7 +215,25 @@ export function Review({
          )}
          <Lane
             title="Recently updated"
-            sub={`review-relevant activity from the last ${RECENT_MAX_AGE_DAYS} days`}
+            sub={
+               <SubDoor
+                  label="What lands in Recently updated"
+                  text={`PRs you can still act on that changed in the last ${RECENT_MAX_AGE_DAYS} days`}
+               >
+                  <p>
+                     A PR shows up here when it changed since you last hit Clear, and that change
+                     was in the last {RECENT_MAX_AGE_DAYS} days. Newest first.
+                  </p>
+                  <p>
+                     PRs you’ve already code reviewed drop out, along with other people’s drafts and
+                     dev-blocked PRs. Your own PRs always stay.
+                  </p>
+                  <p>
+                     The review queue below is a different list: it ranks other people’s PRs that
+                     need a review, whether or not anything changed.
+                  </p>
+               </SubDoor>
+            }
             pulls={lanes.changed}
             cap={8}
             opts={opts}

--- a/frontend-v2/src/views/Review.tsx
+++ b/frontend-v2/src/views/Review.tsx
@@ -108,7 +108,8 @@ export function Review({
    if (lanes.empty) {
       return (
          <EmptyState
-            title="All clear"
+            variant="search"
+            title="Nothing here"
             sub="Nothing to review with these filters. Clear some to see more."
          />
       );

--- a/frontend-v2/src/views/Review.tsx
+++ b/frontend-v2/src/views/Review.tsx
@@ -50,18 +50,24 @@ export function Review({
    const pulls = allPulls.filter(p => !isSnoozed(p.data, snoozed));
    const bots = allBots.filter(p => !isSnoozed(p.data, snoozed));
 
-   // Recently updated: everything that moved since the user last hit Clear,
-   // newest first. A pull can also live in a lane below; this is the "what
-   // happened" glance, not an exclusive bucket — and only the Clear button
-   // empties it (nothing leaves the list silently).
+   // Recently updated: your review work that moved recently, newest first.
+   // Bounded two ways so a quiet board stops resurfacing stale bumps — since
+   // you last hit Clear (isFresh) AND within the last RECENT_MAX_AGE_DAYS.
+   // Already-done and non-reviewable pulls drop out: a PR you hold a live CR
+   // stamp on is finished for you, and others' drafts or dev-blocked PRs
+   // aren't yours to act on. Your own PRs always stay; activity on them is
+   // worth seeing. A pull can still live in a lane below; this is a highlight,
+   // not an exclusive bucket, and only Clear empties it.
+   const RECENT_MAX_AGE_DAYS = 3;
+   const recentCutoff = Date.now() - RECENT_MAX_AGE_DAYS * 24 * 60 * 60 * 1000;
    const changed = pulls
       .filter(p => isFresh(p.data, opts.lastSeen))
-      // others' drafts stay out of the "what changed" glance: a draft you
-      // don't own isn't yours to act on, and draftsMode already keeps them off
-      // the board — they only reach this pool through boardHidden's
-      // review-requested exception (app.tsx). Your own drafts stay; they're
-      // your work.
-      .filter(p => !p.data.draft || p.data.user.login === me)
+      .filter(p => Date.parse(p.data.updated_at) > recentCutoff)
+      .filter(
+         p =>
+            p.data.user.login === me ||
+            (!p.data.draft && p.status !== 'dev_block' && !p.crBy.includes(me))
+      )
       .sort((a, b) => Date.parse(b.data.updated_at) - Date.parse(a.data.updated_at));
 
    const lanes = buildReviewLanes({

--- a/frontend-v2/src/views/Search.tsx
+++ b/frontend-v2/src/views/Search.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from 'react';
+import { closedEpoch, pullKey } from '../../../shared/format';
+import type { DerivedPull } from '../../../shared/model/status';
+import type { PullData } from '../../../shared/types';
+import { matchesClosedQuery, matchesQuery } from '../model/query';
+import { EmptyState } from '../components/bits';
+import { ClosedRow } from '../components/ClosedRow';
+import { GroupHeader, Rows } from '../components/Lane';
+import { Row, type RowOptions } from '../components/Row';
+
+/**
+ * The find surface. The header box's other filters (Repos / People / Weight /
+ * State) NARROW the lens you're on; free text is a different job, FINDING a pull
+ * you know exists, and it needs its own place. So typing anything switches the
+ * board to this lens (app.tsx), which searches every pull the board knows about,
+ * open and closed, ignoring the current lens, the folds, and even the hidden
+ * rules. That last part is the point: Danny's "offer" PR was a real match sitting
+ * collapsed inside Blocked, invisible; here nothing is folded or capped, so a
+ * match can't hide.
+ *
+ * Results are the board's own rows (a closed pull uses ClosedRow), grouped by
+ * state in board order, because position is how this board says "where does
+ * this stand" and a flat list would throw that away. The group a hit lands in
+ * answers the "which section is it in?" question for free.
+ */
+
+type StatusGroup = { label: string; has: (p: DerivedPull) => boolean };
+
+// Each open hit lands in the first group it matches; board-intuitive order.
+const OPEN_GROUPS: StatusGroup[] = [
+   { label: 'Ready to merge', has: p => p.status === 'ready' },
+   { label: 'Needs review', has: p => p.status === 'needs_cr' || p.status === 'needs_recr' },
+   { label: 'Needs QA', has: p => p.status === 'needs_qa' },
+   { label: 'CI failing', has: p => p.status === 'ci_red' },
+   { label: 'CI running', has: p => p.status === 'ci_pending' },
+   { label: 'Blocked', has: p => p.status === 'dev_block' || p.status === 'deploy_block' },
+   { label: 'Conflicts', has: p => p.status === 'unmergeable' },
+   { label: 'Drafts', has: p => p.status === 'draft' },
+];
+
+export function Search({
+   pulls,
+   closed,
+   query,
+   opts,
+   extraBots,
+   names,
+}: {
+   /** the whole open board, unfiltered: search is global, hidden repos included */
+   pulls: DerivedPull[];
+   closed: PullData[];
+   query: string;
+   opts: RowOptions;
+   extraBots: ReadonlySet<string>;
+   names: Readonly<Record<string, string | null>>;
+}) {
+   const me = opts.me;
+   const q = query.trim();
+
+   if (!q) {
+      return (
+         <EmptyState
+            title="Search every PR"
+            sub="Find any open or closed pull by title, repo, #number, author, or label. Tokens like repo:, author:, and is:bot narrow it."
+         />
+      );
+   }
+
+   const openHits = pulls
+      .filter(p => matchesQuery(p, query, me, extraBots, names))
+      .sort((a, b) => b.data.created_at.localeCompare(a.data.created_at));
+   const closedHits = closed
+      .filter(p => matchesClosedQuery(p, query, me, extraBots, names))
+      .sort((a, b) => closedEpoch(b) - closedEpoch(a));
+   const total = openHits.length + closedHits.length;
+
+   if (total === 0) {
+      return (
+         <EmptyState
+            title={`No PR matches “${q}”`}
+            sub="Nothing open or closed matched. Try fewer words, or a #number."
+         />
+      );
+   }
+
+   // first-match assignment; anything a future status wouldn't hit collects in a
+   // trailing "Open" catch-all rather than dropping out of the results
+   const grouped = OPEN_GROUPS.map(g => ({ label: g.label, list: [] as DerivedPull[] }));
+   const other: DerivedPull[] = [];
+   for (const p of openHits) {
+      const g = OPEN_GROUPS.findIndex(gr => gr.has(p));
+      if (g === -1) other.push(p);
+      else grouped[g].list.push(p);
+   }
+
+   const section = (label: string, count: number, rows: ReactNode) => (
+      <section key={label} className={opts.compact ? 'mb-4' : 'mb-7'}>
+         <GroupHeader title={label} count={count} compact={opts.compact} />
+         <Rows>{rows}</Rows>
+      </section>
+   );
+
+   return (
+      <>
+         <div className="mb-5">
+            <h2 className="m-0 text-base leading-snug font-semibold text-ink">Search</h2>
+            <p className="mt-0.5 text-xs text-ink-3">
+               {total} {total === 1 ? 'match' : 'matches'} for “{q}” across open and closed PRs
+            </p>
+         </div>
+         {grouped.map(g =>
+            g.list.length
+               ? section(
+                    g.label,
+                    g.list.length,
+                    g.list.map(p => <Row key={pullKey(p.data)} pull={p} opts={opts} />)
+                 )
+               : null
+         )}
+         {other.length > 0 &&
+            section(
+               'Open',
+               other.length,
+               other.map(p => <Row key={pullKey(p.data)} pull={p} opts={opts} />)
+            )}
+         {closedHits.length > 0 &&
+            section(
+               'Recently closed',
+               closedHits.length,
+               closedHits.map(p => <ClosedRow key={pullKey(p)} pull={p} lastSeen={opts.lastSeen} />)
+            )}
+      </>
+   );
+}

--- a/frontend-v2/src/views/Search.tsx
+++ b/frontend-v2/src/views/Search.tsx
@@ -60,6 +60,7 @@ export function Search({
    if (!q) {
       return (
          <EmptyState
+            variant="search"
             title="Search every PR"
             sub="Find any open or closed pull by title, repo, #number, author, or label. Tokens like repo:, author:, and is:bot narrow it."
          />
@@ -77,6 +78,7 @@ export function Search({
    if (total === 0) {
       return (
          <EmptyState
+            variant="search"
             title={`No PR matches “${q}”`}
             sub="Nothing open or closed matched. Try fewer words, or a #number."
          />

--- a/frontend-v2/src/views/Search.tsx
+++ b/frontend-v2/src/views/Search.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode, useDeferredValue } from 'react';
 import { closedEpoch, pullKey } from '../../../shared/format';
 import type { DerivedPull } from '../../../shared/model/status';
 import type { PullData } from '../../../shared/types';
@@ -55,7 +55,16 @@ export function Search({
    names: Readonly<Record<string, string | null>>;
 }) {
    const me = opts.me;
-   const q = query.trim();
+   // keep the box instant: setQuery is urgent (the input updates immediately),
+   // but the heavy filter + group + render of results runs off a deferred copy,
+   // so React shows the previous query's hits (dimmed) and can abandon a stale
+   // intermediate render on fast typing instead of blocking the keystroke.
+   // useDeferredValue beats a fixed debounce here: no latency on a fast machine,
+   // adaptive on a slow one, and interruptible. On mount it equals `query`, and
+   // App only mounts this view for a non-empty query, so it never filters on ''.
+   const deferred = useDeferredValue(query);
+   const stale = deferred !== query;
+   const q = deferred.trim();
 
    if (!q) {
       return (
@@ -68,10 +77,10 @@ export function Search({
    }
 
    const openHits = pulls
-      .filter(p => matchesQuery(p, query, me, extraBots, names))
+      .filter(p => matchesQuery(p, deferred, me, extraBots, names))
       .sort((a, b) => b.data.created_at.localeCompare(a.data.created_at));
    const closedHits = closed
-      .filter(p => matchesClosedQuery(p, query, me, extraBots, names))
+      .filter(p => matchesClosedQuery(p, deferred, me, extraBots, names))
       .sort((a, b) => closedEpoch(b) - closedEpoch(a));
    const total = openHits.length + closedHits.length;
 
@@ -103,7 +112,9 @@ export function Search({
    );
 
    return (
-      <>
+      // dim while the deferred query is still catching up, so a stale result set
+      // reads as "updating" instead of final
+      <div className={`transition-opacity duration-150 ease-out ${stale ? 'opacity-60' : ''}`}>
          <div className="mb-5">
             <h2 className="m-0 text-base leading-snug font-semibold text-ink">Search</h2>
             <p className="mt-0.5 text-xs text-ink-3">
@@ -131,6 +142,6 @@ export function Search({
                closedHits.length,
                closedHits.map(p => <ClosedRow key={pullKey(p)} pull={p} lastSeen={opts.lastSeen} />)
             )}
-      </>
+      </div>
    );
 }

--- a/frontend-v2/src/views/Search.tsx
+++ b/frontend-v2/src/views/Search.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useDeferredValue } from 'react';
+import type { ReactNode } from 'react';
 import { closedEpoch, pullKey } from '../../../shared/format';
 import type { DerivedPull } from '../../../shared/model/status';
 import type { PullData } from '../../../shared/types';
@@ -42,6 +42,7 @@ export function Search({
    pulls,
    closed,
    query,
+   stale = false,
    opts,
    extraBots,
    names,
@@ -49,22 +50,19 @@ export function Search({
    /** the whole open board, unfiltered: search is global, hidden repos included */
    pulls: DerivedPull[];
    closed: PullData[];
+   /** already the DEFERRED query: App defers it so this view's first-keystroke
+    * MOUNT is a low-priority, time-sliced render rather than a synchronous block
+    * (a broad query renders hundreds of heavy rows). */
    query: string;
+   /** the deferred query is still catching up to what's typed, so dim the
+    * results to read as "updating" rather than final */
+   stale?: boolean;
    opts: RowOptions;
    extraBots: ReadonlySet<string>;
    names: Readonly<Record<string, string | null>>;
 }) {
    const me = opts.me;
-   // keep the box instant: setQuery is urgent (the input updates immediately),
-   // but the heavy filter + group + render of results runs off a deferred copy,
-   // so React shows the previous query's hits (dimmed) and can abandon a stale
-   // intermediate render on fast typing instead of blocking the keystroke.
-   // useDeferredValue beats a fixed debounce here: no latency on a fast machine,
-   // adaptive on a slow one, and interruptible. On mount it equals `query`, and
-   // App only mounts this view for a non-empty query, so it never filters on ''.
-   const deferred = useDeferredValue(query);
-   const stale = deferred !== query;
-   const q = deferred.trim();
+   const q = query.trim();
 
    if (!q) {
       return (
@@ -77,10 +75,10 @@ export function Search({
    }
 
    const openHits = pulls
-      .filter(p => matchesQuery(p, deferred, me, extraBots, names))
+      .filter(p => matchesQuery(p, query, me, extraBots, names))
       .sort((a, b) => b.data.created_at.localeCompare(a.data.created_at));
    const closedHits = closed
-      .filter(p => matchesClosedQuery(p, deferred, me, extraBots, names))
+      .filter(p => matchesClosedQuery(p, query, me, extraBots, names))
       .sort((a, b) => closedEpoch(b) - closedEpoch(a));
    const total = openHits.length + closedHits.length;
 

--- a/frontend-v2/src/views/Stats.tsx
+++ b/frontend-v2/src/views/Stats.tsx
@@ -127,6 +127,7 @@ export function Stats({
    if (!pulls.length && !closed.length) {
       return (
          <EmptyState
+            variant="search"
             title="No data yet"
             sub="Nothing open or recently closed matching your filters."
          />

--- a/models/pull.js
+++ b/models/pull.js
@@ -5,6 +5,7 @@ import queue from '../lib/pull-queue.js';
 import debug from '../lib/debug.js';
 import DBPull from './db_pull.js';
 import getLogin from '../lib/get-user-login.js';
+import { isBot } from '../lib/review-model.js';
 
 const log = debug('pulldasher:pull');
 
@@ -204,6 +205,11 @@ class Pull {
          // participants/signature tagging but never shipped; the board only
          // needs these two facts (a "quiet since" signal), not the rows.
          comment_count: this.comments.length,
+         // Bot comments (a `[bot]` login or config.json's `bots` list) must
+         // never drive the human-review nudge or wake a snooze -- see
+         // lib/review-model.js's isBot for the shared bot check.
+         human_comment_count: this.comments.filter(comment => !isBot(comment.data.user.login))
+            .length,
          last_comment_at: this.comments.length
             ? new Date(Math.max(...this.comments.map(c => c.data.created_at.getTime())))
             : null,

--- a/shared/model/status.ts
+++ b/shared/model/status.ts
@@ -281,7 +281,9 @@ export function derive(
    // as a harmless extra name.
    const unstampedReviewers = st.unstamped_reviewers ?? [];
    const changesRequestedBy = unique(
-      unstampedReviewers.filter(r => r.state === 'CHANGES_REQUESTED').map(r => r.login)
+      unstampedReviewers
+         .filter(r => r.state === 'CHANGES_REQUESTED' && !isSuffixBot(r.login))
+         .map(r => r.login)
    );
    const everStamped = new Set([
       ...st.allCR.map(s => s.data.user.login),

--- a/shared/model/status.ts
+++ b/shared/model/status.ts
@@ -276,9 +276,12 @@ export function derive(
    // APPROVED review already lands as a CR signature server-side) plus
    // comment-only participants: the "engaged but no stamp to show for it"
    // pool rowNote draws "answer their review" / "in discussion with" from.
-   // isSuffixBot is enough here: this model module has no reason to depend on
-   // config.json's `bots` list, and a missed non-suffixed bot just shows up
-   // as a harmless extra name.
+   // changesRequestedBy (below) and engagedNoStamp both filter with
+   // isSuffixBot, not isBotLogin, by the shared model layer's deliberate
+   // convention (visibility.ts:30-36): this module has no reason to depend on
+   // config.json's `bots` list. That's not a live gap — the config-listed
+   // bots (ifixit-systems, Copilot) aren't reviewers, so they never appear in
+   // unstamped_reviewers to begin with.
    const unstampedReviewers = st.unstamped_reviewers ?? [];
    const changesRequestedBy = unique(
       unstampedReviewers

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -109,6 +109,11 @@ export interface PullData {
       commit_statuses: CommitStatus[];
       /** discussion aggregates; absent on servers older than the field */
       comment_count?: number;
+      /** comment_count with bot-authored comments (a `[bot]` login or
+       * config.json's `bots` list) excluded, so bot chatter can't drive the
+       * human-review nudge or wake a snooze. Optional and additive: older
+       * servers omit it, so a consumer falls back to comment_count. */
+      human_comment_count?: number;
       last_comment_at?: DateString | null;
       /** reviewers whose latest verdict has no signature of its own (CHANGES_
        * REQUESTED/COMMENTED/DISMISSED — an APPROVED review already shows up


### PR DESCRIPTION
Post-launch cleanup for the new review board. Using it every day turned up three things it got wrong. You could not find a PR you knew existed. PRs that had waited longest for a review got pushed out of sight. And PRs opened by bots counted as work a person had done.

## Search finds any PR now

Danny went looking for his "offer" PR and could not find it. The match was real, but 1) it sat inside the Blocked section, which was collapsed, and 2) closed PRs were never searched at all.

Typing now switches the board to a results page. It searches every PR pulldasher knows, open and closed, ignoring the tab you are on and the filters you set. Nothing is collapsed or cut off. Results sit in the board's own sections, so where a hit lands tells you its state.

Typing also used to re-filter all 598 open PRs on each keystroke, and the first character blocked the page for 347 ms. Same 74 results now, nothing blocking.

## The board hid work it exists to show

- **Starving section:** a PR that had waited too long got moved out of the queue into this section, which shows only the first few. A busy repo filled it up and pushed a starved ifixit PR behind "show more". It was gone from its own repo block too, so it never came back. Starved PRs and code-region matches stay in the queue now, and those sections show copies.

- **Recently updated:** it listed every PR that changed since you last hit Clear, including ones you had already stamped and bumps from over a week ago. Now it only shows the last 3 days, and drops PRs you hold a live code review stamp on, other people's drafts, and dev-blocked ones.

- **Notification bell:** Kyle got a nudge to "Return the favor to Angel, fixbot#3116" that stayed in the bell after #3116 merged ([report](https://ifixit.slack.com/archives/C6YD8UBS7/p1785179041512159)). An entry clears once every PR it names is off the board.

## Bot activity counted as human review

Bots open a lot of our PRs and `claude[bot]` reviews most of them.

- A bot's comment or review made the board say a PR had changes requested, or that you owed a re-review, and it woke PRs you had snoozed. Both ignore bots now.

- Hiding bots also emptied them out of the CI tab and Ready to merge, where you still want a bot's red build and its one-press-from-done PR. Hiding clears the review queue and the bot section only.

- `ifixit-systems` and `Copilot` have no `[bot]` in their names, so nothing recognized them as bots. They are in the config now.

<details>
<summary>Four smaller fixes</summary>

- The snooze tooltip promised "until it changes", but comments and reviews arrive on a path that never touches `updated_at`, so they never woke a snooze. They do now.
- On a phone, tapping a PR title opened the PR and then popped its hover preview on the board you had just left. Only a real mouse or pen arms the preview now.
- The "shipped while you were away" message threw the titles away and showed a bare count. It names the PRs now, and it plus the notifications stopped cutting text off.
- Ten to fifteen pinned filters wrapped the whole filter bar and shoved the controls around. They got their own scrolling row.

</details>

## QA

- [x] 454 vitest tests pass, plus `tsc --noEmit` and `vite build`.
- [x] 61 backend tests pass after `npm run build:shared`.
- [x] `npx eslint ./` reports 0 errors (24 warnings, all pre-existing).
- [x] Reviewed by a Fable-model pass over the full `git diff master...HEAD`; every finding addressed.
- [ ] Collapse the Blocked section, set a repo filter, search `offer`. The merged PR should show up.
- [ ] Search a broad term such as `a`. Typing should not stutter.
- [ ] Snooze a PR that `claude[bot]` reviews. The bot's review should not wake it.
- [ ] Tap a PR title on a phone. No preview should pop up on the board behind it.

## Deploy notes

- **Both instances run the July 25 build, not the tip of this branch.** The search, notification, and speed commits are not deployed.
- Prod and dev `config.js` both need `ifixit-systems` and `Copilot` in their bots list. Both are done (see the deploy comment below).
- No DB changes. `human_comment_count` is a new field on the wire; an older client ignores it and the snooze falls back to `comment_count`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
